### PR TITLE
ENH: node_density() based on nodes and length

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,7 @@ intensity
    elements_count
    floor_area_ratio
    gross_density
+   node_density
    reached
 
 connectivity

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -474,7 +474,7 @@ def reached(streets, elements, unique_id, spatial_weights=None, mode='count', va
     return series
 
 
-def node_density(left, right, spatial_weights, node_start='node_start', node_end='node_end'):
+def node_density(left, right, spatial_weights, weighted=False, node_degree=None, node_start='node_start', node_end='node_end'):
     """
     Calculate the density of nodes within topological steps defined in spatial_weights.
 
@@ -492,6 +492,10 @@ def node_density(left, right, spatial_weights, node_start='node_start', node_end
         GeoDataFrame containing edges of street network
     spatial_weights : libpysal.weights, optional
         spatial weights matrix capturing relationship between nodes within set topological distance
+    weighted : bool
+        if True density will take into account node degree as k-1
+    node_degree : str
+        name of the column of left gdf containing node degree
     node_start : str
         name of the column of right gdf containing id of starting node
     node_end : str
@@ -520,12 +524,17 @@ def node_density(left, right, spatial_weights, node_start='node_start', node_end
 
         neighbours = list(spatial_weights.neighbors[index])
         neighbours.append(index)
+        if weighted:
+            neighbour_nodes = left.iloc[neighbours]
+            number_nodes = sum(neighbour_nodes[node_degree] - 1)
+        else:
+            number_nodes = len(neighbours)
 
         edg = right.loc[right['node_start'].isin(neighbours)].loc[right['node_end'].isin(neighbours)]
         length = sum(edg.geometry.length)
 
         if length > 0:
-            results_list.append(len(neighbours) / length)
+            results_list.append(number_nodes / length)
         else:
             results_list.append(0)
 

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -474,27 +474,28 @@ def reached(streets, elements, unique_id, spatial_weights=None, mode='count', va
     return series
 
 
-def node_density(objects, nodes, spatial_weights=None, order=9, node_id='nodeID'):
+def node_density(left, right, spatial_weights, node_start='node_start', node_end='node_end'):
     """
-    Calculate the density of nodes within topological steps of morphological tessellation.
-    Node is marked as reached if reached cell con
+    Calculate the density of nodes within topological steps defined in spatial_weights.
+
+    Calculated as number of nodes within k steps / cummulative length of street network within k steps.
+    node_start and node_end is standard output of :py:func:`momepy.nx_to_gdf` and is compulsory.
 
     .. math::
 
 
     Parameters
     ----------
-    objects : GeoDataFrame
-        GeoDataFrame containing tessellation objects to analyse
-    nodes : GeoDataFrame
-        GeoDataFrame containing nodes
+    left : GeoDataFrame
+        GeoDataFrame containing nodes of street network
+    right : GeoDataFrame
+        GeoDataFrame containing edges of street network
     spatial_weights : libpysal.weights, optional
-        spatial weights matrix - If None, Queen contiguity matrix of selected order will be calculated
-        based on objects.
-    order : int
-        order of Queen contiguity
-    node_id : str
-        name of the column of objects gdf with node id.
+        spatial weights matrix capturing relationship between nodes within set topological distance
+    node_start : str
+        name of the column of right gdf containing id of starting node
+    node_end : str
+        name of the column of right gdf containing id of ending node
 
     Returns
     -------
@@ -512,25 +513,22 @@ def node_density(objects, nodes, spatial_weights=None, order=9, node_id='nodeID'
     # define empty list for results
     results_list = []
 
-    print('Calculating gross density...')
-
-    if not all(objects.index == range(len(objects))):
-        raise ValueError('Index is not consecutive range 0:x, spatial weights will not match objects.')
-
-    if spatial_weights is None:
-        print('Generating weights matrix (Queen) of {} topological steps...'.format(order))
-        from momepy import Queen_higher
-        # matrix to define area of analysis (more steps)
-        spatial_weights = Queen_higher(k=order, geodataframe=objects)
+    print('Calculating node density...')
 
     # iterating over rows one by one
-    for index, row in tqdm(objects.iterrows(), total=objects.shape[0]):
-        neighbours = spatial_weights.neighbors[index]
+    for index, row in tqdm(left.iterrows(), total=left.shape[0]):
+
+        neighbours = list(spatial_weights.neighbors[index])
         neighbours.append(index)
-        sub = objects.iloc[neighbours]
-        subnodes = set(sub['nodeID'])
-        results_list.append((len(subnodes) / sum(sub.geometry.area)) * 10000)
+
+        edg = right.loc[right['node_start'].isin(neighbours)].loc[right['node_end'].isin(neighbours)]
+        length = sum(edg.geometry.length)
+
+        if length > 0:
+            results_list.append(len(neighbours) / length)
+        else:
+            results_list.append(0)
 
     series = pd.Series(results_list)
-    print('Gross density calculated.')
+    print('Node density calculated.')
     return series

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -82,3 +82,10 @@ class TestIntensity:
         assert max(area_v) == 79169.31385861784
         assert max(mean_v) == 7916.931385861784
         assert max(std_v) == 8995.18003493457
+
+    def test_node_density(self):
+        nx = mm.gdf_to_nx(self.df_streets)
+        nodes, edges, W = mm.nx_to_gdf(nx, spatial_weights=True)
+        sw = mm.Queen_higher(k=3, weights=W)
+        density = mm.node_density(nodes, edges, sw)
+        assert density.mean() == 0.012690163074599968

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -85,7 +85,10 @@ class TestIntensity:
 
     def test_node_density(self):
         nx = mm.gdf_to_nx(self.df_streets)
+        nx = mm.node_degree(nx)
         nodes, edges, W = mm.nx_to_gdf(nx, spatial_weights=True)
         sw = mm.Queen_higher(k=3, weights=W)
         density = mm.node_density(nodes, edges, sw)
+        weighted = mm.node_density(nodes, edges, sw, weighted=True, node_degree='degree')
         assert density.mean() == 0.012690163074599968
+        assert weighted.mean() == 0.023207675994368446


### PR DESCRIPTION
Another (hopefully final) version of `node_density`. It no longer uses area, but length of reached network as a normalisation.