### PR TITLE
MAINT: use geopandas explode() instead of multi2single (removed)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -125,7 +125,6 @@ utilities
 
    gdf_to_nx
    limit_range
-   multi2single
    nx_to_gdf
    preprocess
    unique_id

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -18,8 +18,6 @@ import osmnx as ox
 import operator
 from libpysal.weights import Queen
 
-from .utils import multi2single
-
 
 def tessellation(buildings, unique_id='uID', cut_buffer=50, queen_corners=False, minimum=2):
     """
@@ -75,7 +73,8 @@ def tessellation(buildings, unique_id='uID', cut_buffer=50, queen_corners=False,
 
     # resolve multipart polygons, singlepart are needed for densification
     print('Converting multipart geometry to singlepart...')
-    objects = multi2single(objects)
+    objects = objects.explode()
+    objects.reset_index(inplace=True, drop=True)
 
     # densify geometry before Voronoi tesselation
     def _densify(geom):
@@ -652,7 +651,8 @@ def blocks(cells, streets, buildings, id_name, unique_id):
     cells_copy = cells_copy.drop([id_name], axis=1)
 
     print('Multipart to singlepart...')
-    blocks = multi2single(blocks)
+    blocks = blocks.explode()
+    blocks.reset_index(inplace=True, drop=True)
 
     blocks['geometry'] = blocks.exterior
 

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -175,43 +175,6 @@ def nx_to_gdf(net, nodes=True, edges=True, spatial_weights=False, nodeID='nodeID
     return gdf_edges
 
 
-def multi2single(gdf):
-    """
-    Convert multi-part geometry of GeoDataFrame to single-part geometries.
-
-    Parameters
-    ----------
-    gpdf : geopandas.GeoDataFrame
-        geopandas.GeoDataFrame
-
-    Returns
-    -------
-    GeoDataFrame
-        GeoDataFrame containing only single-part geometry
-
-    """
-    if gdf.iloc[0].geometry.type in ['Polygon', 'MultiPolygon']:
-        gdf_singlepoly = gdf[gdf.geometry.type == 'Polygon']
-        gdf_multipoly = gdf[gdf.geometry.type == 'MultiPolygon']
-    elif gdf.iloc[0].geometry.type in ['LineString', 'MultiLineString']:
-        gdf_singlepoly = gdf[gdf.geometry.type == 'LineString']
-        gdf_multipoly = gdf[gdf.geometry.type == 'MultiLineString']
-    elif gdf.iloc[0].geometry.type in ['Point', 'MultiPoint']:
-        gdf_singlepoly = gdf[gdf.geometry.type == 'Point']
-        gdf_multipoly = gdf[gdf.geometry.type == 'MultiPoint']
-    else:
-        raise ValueError('Unsupported geometry type:', gdf.iloc[0].geometry.type)
-
-    for i, row in gdf_multipoly.iterrows():
-        Series_geometries = pd.Series(row.geometry)
-        df = pd.concat([gpd.GeoDataFrame(row, crs=gdf_multipoly.crs).T] * len(Series_geometries), ignore_index=True)
-        df['geometry'] = Series_geometries
-        gdf_singlepoly = pd.concat([gdf_singlepoly, df])
-
-    gdf_singlepoly.reset_index(inplace=True, drop=True)
-    return gdf_singlepoly
-
-
 def limit_range(vals, rng):
     """
     Extract values within selected range

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,6 @@ import geopandas as gpd
 import numpy as np
 import libpysal
 
-from shapely.geometry import Polygon, MultiPolygon
-
 import pytest
 
 
@@ -37,14 +35,6 @@ class TestUtils:
             gdf = self.df_tessellation
             gdf.index = gdf.index + 20
             mm.Queen_higher(2, geodataframe=gdf, weights=None)
-
-    def test_multi2single(self):
-        polygon = Polygon([(0, 0), (1, 1), (1, 0)])
-        polygon2 = Polygon([(2, 3), (1, 2), (2, 4)])
-        polygons = MultiPolygon([polygon, polygon2])
-        gdf = gpd.GeoDataFrame(geometry=[polygon, polygon2, polygons])
-        single = mm.multi2single(gdf)
-        assert len(single) == 4
 
     def test_gdf_to_nx(self):
         nx = mm.gdf_to_nx(self.df_streets)


### PR DESCRIPTION
I have found out that `multi2single` is just a duplication of Geopandas `explode`, so I have removed `multi2single`.