### PR TITLE
API: use unique_ID column instead of index for spatial weights

### DIFF
--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -32,7 +32,7 @@ def unique_id(objects):
     return series
 
 
-def Queen_higher(k, geodataframe=None, weights=None):
+def Queen_higher(k, geodataframe=None, weights=None, ids=None):
     """
     Generate spatial weights based on Queen contiguity of order k
 
@@ -68,7 +68,7 @@ def Queen_higher(k, geodataframe=None, weights=None):
     elif geodataframe is not None:
         if not all(geodataframe.index == range(len(geodataframe))):
             raise ValueError('Index is not consecutive range 0:x, spatial weights will not match objects.')
-        first_order = libpysal.weights.Queen.from_dataframe(geodataframe)
+        first_order = libpysal.weights.Queen.from_dataframe(geodataframe, ids=ids)
     else:
         raise Warning('GeoDataFrame of spatial weights must be given.')
 

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -99,27 +99,19 @@ class TestDimensions:
         assert self.df_buildings['long_axis'][0] == check
 
     def test_mean_character(self):
-        self.df_tessellation['mesh'] = mm.mean_character(self.df_tessellation)
-        spatial_weights = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        self.df_tessellation['mesh_sw'] = mm.mean_character(self.df_tessellation, spatial_weights)
+        spatial_weights = Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
         self.df_tessellation['area'] = area = self.df_tessellation.geometry.area
-        self.df_tessellation['mesh_ar'] = mm.mean_character(self.df_tessellation, spatial_weights, values='area')
-        self.df_tessellation['mesh_array'] = mm.mean_character(self.df_tessellation, spatial_weights, values=area)
-        self.df_tessellation['mesh_id'] = mm.mean_character(self.df_tessellation, spatial_weights, values='area', rng=(10, 90))
-        self.df_tessellation['mesh_iq'] = mm.mean_character(self.df_tessellation, spatial_weights, values='area', rng=(25, 75))
-        neighbours = spatial_weights.neighbors[38]
-        total_area = sum(self.df_tessellation.iloc[neighbours].geometry.area) + self.df_tessellation.geometry.area[38]
-        check = total_area / (len(neighbours) + 1)
-        assert self.df_tessellation['mesh'][38] == check
-        assert self.df_tessellation['mesh_sw'][38] == check
-        assert self.df_tessellation['mesh_ar'][38] == check
-        assert self.df_tessellation['mesh_array'][38] == check
+        self.df_tessellation['mesh_ar'] = mm.mean_character(self.df_tessellation, values='area', spatial_weights=spatial_weights, unique_id='uID')
+        self.df_tessellation['mesh_array'] = mm.mean_character(self.df_tessellation, values=area, spatial_weights=spatial_weights, unique_id='uID')
+        self.df_tessellation['mesh_id'] = mm.mean_character(self.df_tessellation, spatial_weights=spatial_weights,
+                                                            values='area', rng=(10, 90), unique_id='uID')
+        self.df_tessellation['mesh_iq'] = mm.mean_character(self.df_tessellation, spatial_weights=spatial_weights,
+                                                            values='area', rng=(25, 75), unique_id='uID')
+        check = 2922.9572601966815
+        assert self.df_tessellation['mesh_ar'][0] == check
+        assert self.df_tessellation['mesh_array'][0] == check
         assert self.df_tessellation['mesh_id'][38] == 2250.2241176070806
-        assert self.df_tessellation['mesh_iq'][38] == 2118.609142733066
-        gdf = self.df_tessellation
-        gdf.index = gdf.index + 20
-        with pytest.raises(ValueError):
-            self.df_tessellation['meshE'] = mm.mean_character(gdf)
+        assert self.df_tessellation['mesh_iq'][38] == 2118.6091427330666
 
     def test_street_profile(self):
         results = mm.street_profile(self.df_streets, self.df_buildings, heights='height')
@@ -140,33 +132,27 @@ class TestDimensions:
         assert results['openness'][0] == 0.5535714285714286
         assert results['heights_deviations'][0] == 5.526848034418866
 
-    def test_weighted_character(self):
-        weighted = mm.weighted_character(self.df_buildings, self.df_tessellation, 'height', 'uID')
-        assert weighted[38] == 18.301521351817303
-
     def test_weighted_character_sw(self):
-        sw = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        weighted = mm.weighted_character(self.df_buildings, self.df_tessellation, 'height', 'uID', sw)
+        sw = Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
+        weighted = mm.weighted_character(self.df_buildings, 'height', sw, 'uID')
         assert weighted[38] == 18.301521351817303
 
     def test_weighted_character_area(self):
         self.df_buildings['area'] = self.df_buildings.geometry.area
-        sw = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        weighted = mm.weighted_character(self.df_buildings, self.df_tessellation, 'height', 'uID', sw, 'area')
+        sw = Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
+        weighted = mm.weighted_character(self.df_buildings, 'height', sw, 'uID', 'area')
         assert weighted[38] == 18.301521351817303
 
     def test_weighted_character_array(self):
         area = self.df_buildings.geometry.area
-        sw = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        weighted = mm.weighted_character(self.df_buildings, self.df_tessellation, 'height', 'uID', sw, area)
+        sw = Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
+        weighted = mm.weighted_character(self.df_buildings, 'height', sw, 'uID', area)
         assert weighted[38] == 18.301521351817303
 
     def test_covered_area(self):
-        sw = Queen_higher(geodataframe=self.df_tessellation, k=1)
-        covered = mm.covered_area(self.df_tessellation)
-        covered_sw = mm.covered_area(self.df_tessellation, sw)
-        assert covered[0] == covered_sw[0]
-        assert covered[0] == 24115.66721833942
+        sw = Queen_higher(geodataframe=self.df_tessellation, k=1, ids='uID')
+        covered_sw = mm.covered_area(self.df_tessellation, sw, 'uID')
+        assert covered_sw[0] == 24115.667218339422
 
     def test_wall(self):
         sw = Queen_higher(geodataframe=self.df_buildings, k=1)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -44,34 +44,27 @@ class TestDistribution:
         self.df_buildings['orient'] = mm.orientation(self.df_buildings)
         self.df_tessellation['orient'] = mm.orientation(self.df_tessellation)
         self.df_buildings['c_align'] = mm.cell_alignment(self.df_buildings, self.df_tessellation, 'orient', 'orient', 'uID')
-        check = abs(self.df_buildings['orient'][0] -
-                    self.df_tessellation[self.df_tessellation['uID'] == self.df_buildings['uID'][0]]['orient'].iloc[0])
+        check = abs(self.df_buildings['orient'][0] - self.df_tessellation[
+            self.df_tessellation['uID'] == self.df_buildings['uID'][0]]['orient'].iloc[0])
         assert self.df_buildings['c_align'][0] == check
 
     def test_alignment(self):
         self.df_buildings['orient'] = mm.orientation(self.df_buildings)
-        self.df_buildings['align'] = mm.alignment(self.df_buildings, self.df_tessellation, 'orient', 'uID')
-        sw = Queen.from_dataframe(self.df_tessellation)
-        self.df_buildings['align_sw'] = mm.alignment(self.df_buildings, self.df_tessellation, 'orient', 'uID', sw)
-        check = 18.299481296455237
-        assert self.df_buildings['align'][0] == check
-        assert self.df_buildings['align_sw'][0] == check
+        sw = Queen.from_dataframe(self.df_tessellation, ids='uID')
+        self.df_buildings['align_sw'] = mm.alignment(self.df_buildings, sw, 'uID', 'orient')
+        assert self.df_buildings['align_sw'][0] == 18.299481296455237
 
     def test_neighbour_distance(self):
-        self.df_buildings['dist'] = mm.neighbour_distance(self.df_buildings, self.df_tessellation, 'uID')
-        sw = Queen.from_dataframe(self.df_tessellation)
-        self.df_buildings['dist_sw'] = mm.neighbour_distance(self.df_buildings, self.df_tessellation, 'uID', sw)
+        sw = Queen.from_dataframe(self.df_tessellation, ids='uID')
+        self.df_buildings['dist_sw'] = mm.neighbour_distance(self.df_buildings, sw, 'uID')
         check = 29.18589019096464
-        assert self.df_buildings['dist'][0] == check
         assert self.df_buildings['dist_sw'][0] == check
 
     def test_mean_interbuilding_distance(self):
-        self.df_buildings['m_dist'] = mm.mean_interbuilding_distance(self.df_buildings, self.df_tessellation, 'uID')
-        sw = Queen.from_dataframe(self.df_tessellation)
-        swh = mm.Queen_higher(k=3, geodataframe=self.df_tessellation)
-        self.df_buildings['m_dist_sw'] = mm.mean_interbuilding_distance(self.df_buildings, self.df_tessellation, 'uID', sw, swh)
+        sw = Queen.from_dataframe(self.df_tessellation, ids='uID')
+        swh = mm.Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
+        self.df_buildings['m_dist_sw'] = mm.mean_interbuilding_distance(self.df_buildings, sw, 'uID', swh)
         check = 29.305457092042744
-        assert self.df_buildings['m_dist'][0] == check
         assert self.df_buildings['m_dist_sw'][0] == check
 
     def test_neighbouring_street_orientation_deviation(self):
@@ -80,21 +73,17 @@ class TestDistribution:
         assert self.df_streets['dev'].mean() == check
 
     def test_building_adjacency(self):
-        self.df_buildings['adj'] = mm.building_adjacency(self.df_buildings, self.df_tessellation)
-        sw = Queen.from_dataframe(self.df_buildings)
-        swh = mm.Queen_higher(k=3, geodataframe=self.df_tessellation)
-        self.df_buildings['adj_sw'] = mm.building_adjacency(self.df_buildings, self.df_tessellation, spatial_weights=sw, spatial_weights_higher=swh)
+        sw = Queen.from_dataframe(self.df_buildings, ids='uID')
+        swh = mm.Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
+        self.df_buildings['adj_sw'] = mm.building_adjacency(self.df_buildings, spatial_weights=sw, unique_id='uID', spatial_weights_higher=swh)
         check = 0.2613824113909074
-        assert self.df_buildings['adj'].mean() == check
         assert self.df_buildings['adj_sw'].mean() == check
 
     def test_neighbours(self):
-        self.df_tessellation['nei'] = mm.neighbours(self.df_tessellation)
-        sw = Queen.from_dataframe(self.df_tessellation)
-        self.df_tessellation['nei_sw'] = mm.neighbours(self.df_tessellation, sw)
-        self.df_tessellation['nei_wei'] = mm.neighbours(self.df_tessellation, sw, weighted=True)
+        sw = Queen.from_dataframe(self.df_tessellation, ids='uID')
+        self.df_tessellation['nei_sw'] = mm.neighbours(self.df_tessellation, sw, 'uID')
+        self.df_tessellation['nei_wei'] = mm.neighbours(self.df_tessellation, sw, 'uID', weighted=True)
         check = 5.180555555555555
         check_w = 0.029066398893536072
-        assert self.df_tessellation['nei'].mean() == check
         assert self.df_tessellation['nei_sw'].mean() == check
         assert self.df_tessellation['nei_wei'].mean() == check_w

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -16,33 +16,25 @@ class TestDiversity:
         self.df_tessellation = gpd.read_file(test_file_path, layer='tessellation')
         self.df_buildings['height'] = np.linspace(10., 30., 144)
         self.df_tessellation['area'] = mm.area(self.df_tessellation)
+        self.sw = Queen_higher(k=3, geodataframe=self.df_tessellation, ids='uID')
 
     def test_rng(self):
-        full = mm.rng(self.df_tessellation, 'area', order=3)
-        assert full[0] == 8255.372874447059
-        sw = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        full_sw = mm.rng(self.df_tessellation, 'area', spatial_weights=sw)
+        full_sw = mm.rng(self.df_tessellation, 'area', self.sw, 'uID')
         assert full_sw[0] == 8255.372874447059
         area = self.df_tessellation['area']
-        full2 = mm.rng(self.df_tessellation, area, order=3)
+        full2 = mm.rng(self.df_tessellation, area, self.sw, 'uID')
         assert full2[0] == 8255.372874447059
-        limit = mm.rng(self.df_tessellation, 'area', spatial_weights=sw, rng=(10, 90))
+        limit = mm.rng(self.df_tessellation, 'area', self.sw, 'uID', rng=(10, 90))
         assert limit[0] == 4122.139212736442
 
     def test_theil(self):
-        full = mm.theil(self.df_tessellation, 'area', order=3)
-        assert full[0] == 0.2574468431886534
-        sw = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        full_sw = mm.theil(self.df_tessellation, 'area', spatial_weights=sw)
-        assert full_sw[0] == 0.2574468431886534
-        limit = mm.theil(self.df_tessellation, 'area', spatial_weights=sw, rng=(10, 90))
+        full_sw = mm.theil(self.df_tessellation, 'area', self.sw, 'uID')
+        assert full_sw[0] == 0.25744684318865324
+        limit = mm.theil(self.df_tessellation, 'area', self.sw, 'uID', rng=(10, 90))
         assert limit[0] == 0.13302952097969373
 
     def test_simpson(self):
-        ht = mm.simpson(self.df_tessellation, 'area', order=3)
-        assert ht[0] == 0.385
-        sw = Queen_higher(k=3, geodataframe=self.df_tessellation)
-        ht_sw = mm.simpson(self.df_tessellation, 'area', spatial_weights=sw)
+        ht_sw = mm.simpson(self.df_tessellation, 'area', self.sw, 'uID')
         assert ht_sw[0] == 0.385
-        quan_sw = mm.simpson(self.df_tessellation, 'area', spatial_weights=sw, binning='quantiles', k=3)
+        quan_sw = mm.simpson(self.df_tessellation, 'area', self.sw, 'uID', binning='quantiles', k=3)
         assert quan_sw[0] == 0.395

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -1,4 +1,3 @@
-import pytest
 import momepy as mm
 import geopandas as gpd
 import numpy as np

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -21,12 +21,12 @@ class TestIntensity:
         self.df_buildings, self.df_tessellation, self.blocks = mm.blocks(self.df_tessellation, self.df_streets, self.df_buildings, 'bID', 'uID')
 
     def test_covered_area_ratio(self):
-        car = mm.covered_area_ratio(self.df_tessellation, self.df_buildings, 'area', 'area')
+        car = mm.covered_area_ratio(self.df_tessellation, self.df_buildings, 'area', 'area', 'uID')
         check = 0.3206556897709747
         assert car.mean() == check
 
     def test_floor_area_ratio(self):
-        far = mm.floor_area_ratio(self.df_tessellation, self.df_buildings, 'area', 'fl_area')
+        far = mm.floor_area_ratio(self.df_tessellation, self.df_buildings, 'area', 'fl_area', 'uID')
         check = 1.910949846262234
         assert far.mean() == check
 
@@ -49,11 +49,9 @@ class TestIntensity:
         assert courtyards_wm.mean() == check
 
     def test_blocks_count(self):
-        count = mm.blocks_count(self.df_tessellation, 'bID', spatial_weights=None, order=5)
-        sw = mm.Queen_higher(k=5, geodataframe=self.df_tessellation)
-        count2 = mm.blocks_count(self.df_tessellation, 'bID', spatial_weights=sw)
+        sw = mm.Queen_higher(k=5, geodataframe=self.df_tessellation, ids='uID')
+        count2 = mm.blocks_count(self.df_tessellation, 'bID', sw, 'uID')
         check = 3.142437439120778e-05
-        assert count.mean() == check
         assert count2.mean() == check
 
     def test_reached(self):


### PR DESCRIPTION
To simplify some methods and make them more explicit rather than implicit, majority of spatial weights now require being based on unique ID rather than on index. That allows using weights derived from tessellation directly on buildings and vice versa.