### PR TITLE
REF: remove osmnx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ from GitHub:
 
 Please ensure that you have all dependencies installed as `momepy` setup
 currently does not specify dependency requirements.
-Momepy depends on the following packages: `geopandas`, `libpysal`, `osmnx` and `tqdm`. All of the packages are currently required, which will be changed in future.
+Momepy depends on the following packages: `geopandas`, `libpysal`, and `tqdm`. All of the packages are currently required, which will be changed in future.
 
 ## References
 - Dibble J, Prelorendjos A, Romice O, et al. (2017) On the origin of spaces: Morphometric foundations of urban form evolution. Environment and Planning B: Urban Analytics and City Science 24(1): 239980831772507–24.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ from GitHub::
 
 Please ensure that you have all dependencies installed as ``momepy`` setup
 currently does not specify dependency requirements.
-Momepy depends on the following packages: ``geopandas``, ``libpysal``, ``osmnx``
+Momepy depends on the following packages: ``geopandas``, ``libpysal``
 and ``tqdm``. All of the packages are currently required, which will be
 changed in future.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ from GitHub via PIP::
 
 Please ensure that you have all dependencies installed as ``momepy`` setup
 currently does not specify dependency requirements.
-Momepy depends on the following packages: ``geopandas``, ``libpysal``, ``osmnx``
+Momepy depends on the following packages: ``geopandas``, ``libpysal``
 and ``tqdm``. All of the packages are currently required, which will be
 changed in future.
 
@@ -21,6 +21,6 @@ to install all dependencies via `conda` from `conda-forge`::
 
     conda config --add channels conda-forge  # ensure that conda-forge is in your list of channels on the top
     conda config --set channel_priority strict  # strict priority to install all from conda-forge
-    conda create --name momepy_env geopandas libpysal osmnx tqdm
+    conda create --name momepy_env geopandas libpysal tqdm
     conda activate momepy_env
     pip install git+git://github.com/martinfleis/momepy.git

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -52,5 +52,5 @@ class TestElements:
         dense = mm.elements._split_lines(large, 100, self.df_buildings.crs)
         small = mm.buffered_limit(self.df_buildings, 30)
         dense2 = mm.elements._split_lines(small, 100, self.df_buildings.crs)
-        assert len(dense) == 237
-        assert len(dense2) == 573
+        assert len(dense) == 273
+        assert len(dense2) == 667

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -46,3 +46,11 @@ class TestElements:
         self.df_buildings['nID'] = mm.get_network_id(self.df_buildings, self.df_streets, 'uID', 'nID')
         ids = mm.get_node_id(self.df_buildings, nodes, edges, 'nodeID', 'nID')
         assert not ids.isna().any()
+
+    def test__split_lines(self):
+        large = mm.buffered_limit(self.df_buildings, 100)
+        dense = mm.elements._split_lines(large, 100, self.df_buildings.crs)
+        small = mm.buffered_limit(self.df_buildings, 30)
+        dense2 = mm.elements._split_lines(small, 100, self.df_buildings.crs)
+        assert len(dense) == 237
+        assert len(dense2) == 573


### PR DESCRIPTION
Remove `osmnx` dependency as it was used only once in tessellation. `_split_lines` is introduced instead. It is 10x faster than previous in division, but might be slower, but more precise in rtree selection of cells to cut.