### PR TITLE
ENH: Allow inequaliy and mapclassify to be used instead pysal and vv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: python
 
 sudo: false
 
-dist: xenial   # required for Python >= 3.7
-
-python:
-  - "3.6"
-  - "3.7"
+matrix:
+  include:
+    - env: ENV_FILE="ci/travis/37-pysal.yaml"
+    - env: ENV_FILE="ci/travis/37-mc.yaml"
 
 install:
   - sudo apt-get update
@@ -23,9 +22,8 @@ install:
   - conda config --set channel_priority strict
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-  - conda install geopandas libpysal osmnx tqdm pysal mapclassify pytest pytest-cov codecov
+  - conda env create --file="${ENV_FILE}"
+  - source activate test
   - python setup.py install
   - conda list
 

--- a/ci/travis/37-mc.yaml
+++ b/ci/travis/37-mc.yaml
@@ -1,0 +1,14 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - geopandas
+  - libpysal
+  - networkx
+  - tqdm
+  - pytest
+  - pytest-cov
+  - codecov
+  - inequality
+  - mapclassify

--- a/ci/travis/37-mc.yaml
+++ b/ci/travis/37-mc.yaml
@@ -10,5 +10,6 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - inequality
   - mapclassify
+  - pip:
+    - inequality

--- a/ci/travis/37-pysal.yaml
+++ b/ci/travis/37-pysal.yaml
@@ -1,0 +1,13 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - geopandas
+  - libpysal
+  - networkx
+  - tqdm
+  - pytest
+  - pytest-cov
+  - codecov
+  - pysal

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from momepy import Queen_higher
 
+import pytest
 
 class TestDiversity:
 
@@ -40,9 +41,9 @@ class TestDiversity:
 
     def test_gini(self):
         full_sw = mm.gini(self.df_tessellation, 'area', self.sw, 'uID')
-        assert full_sw[0] == 0.39453880038576933
+        assert full_sw[0] == 0.39453880039926703
         limit = mm.gini(self.df_tessellation, 'area', self.sw, 'uID', rng=(10, 90))
-        assert limit[0] == 0.28532814171764387
+        assert limit[0] == 0.28532814172859305
         self.df_tessellation['negative'] = self.df_tessellation.area - self.df_tessellation.area.mean()
-        neg = mm.gini(self.df_tessellation, 'negative', self.sw, 'uID')
-        assert neg[0] == 0.43135969210184627
+        with pytest.raises(ValueError):
+            mm.gini(self.df_tessellation, 'negative', self.sw, 'uID')


### PR DESCRIPTION
Within diversity module, allow `pysal` to be used for everything or separate `mapclassify` and `inequality` packages.  