### PR TITLE
ENH: snap_street_network_edge allow limit to avoid dissolve

### DIFF
--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -460,7 +460,7 @@ def mean_interbuilding_distance(gdf, spatial_weights, unique_id, spatial_weights
     Calculate the mean interbuilding distance within x topological steps
 
     Interbuilding distances are calculated between buildings on adjacent cells based on `spatial_weights`,
-    while the extend is defined in `spatial_weights_higher`.
+    while the extent is defined in `spatial_weights_higher`.
 
     .. math::
 
@@ -653,7 +653,8 @@ def building_adjacency(gdf, spatial_weights_higher, unique_id, spatial_weights=N
     Calculate the level of building adjacency
 
     Building adjacency reflects how much buildings tend to join together into larger structures.
-    It is calculated as a ratio of joined built-up structures and buildings within k topological steps.
+    It is calculated as a ratio of joined built-up structures and buildings within
+    the extent defined in `spatial_weights_higher`.
 
     .. math::
 
@@ -662,13 +663,13 @@ def building_adjacency(gdf, spatial_weights_higher, unique_id, spatial_weights=N
     ----------
     gdf : GeoDataFrame
         GeoDataFrame containing objects to analyse
-    spatial_weights_higher : libpysal.weights, optional
+    spatial_weights_higher : libpysal.weights
         spatial weights matrix
     unique_id : str
         name of the column with unique id used as spatial_weights index
     spatial_weights : libpysal.weights, optional
         spatial weights matrix - If None, Queen contiguity matrix will be calculated
-        based on gdf. It is to denote adjacent buildings (note: based on index, not ID).
+        based on gdf. It is to denote adjacent buildings (note: based on unique ID).
 
     Returns
     -------

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -576,11 +576,17 @@ def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=No
     sindex = network.sindex
     print('Building R-tree for buildings...')
     bindex = buildings.sindex
-    if tessellation is not None:
-        print('Dissolving tesselation...')
-        geometry = tessellation.geometry.unary_union.boundary
-    if edge is not None:
-        geometry = edge.boundary
+
+    def _get_geometry():
+        if edge is not None:
+            return edge.boundary
+        elif tessellation is not None:
+            print('Dissolving tesselation...')
+            return tessellation.geometry.unary_union.boundary
+        else:
+            return None
+
+    geometry = _get_geometry()
 
     print('Snapping...')
     # iterating over each street segment

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -580,11 +580,10 @@ def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=No
     def _get_geometry():
         if edge is not None:
             return edge.boundary
-        elif tessellation is not None:
+        if tessellation is not None:
             print('Dissolving tesselation...')
             return tessellation.geometry.unary_union.boundary
-        else:
-            return None
+        return None
 
     geometry = _get_geometry()
 

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -217,7 +217,7 @@ def preprocess(buildings, size=30, compactness=True, islands=True):
     If feature area is smaller than set size it will be a) deleted if it does not
     touch any other feature; b) will be joined to feature with which it shares the
     longest boundary. If feature is fully within other feature, these will be joined.
-    If feature's circular compactness (:py:func:`momepy.shape.circular compactness`)
+    If feature's circular compactness (:py:func:`momepy.circular_compactness`)
     is < 0.2, it will be joined to feature with which it shares the longest boundary.
     Function does two loops through.
 
@@ -409,7 +409,7 @@ def network_false_nodes(gdf):
     return streets
 
 
-def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=None, tolerance_edge=None):
+def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=None, tolerance_edge=None, edge=None):
     """
     Fix street network before performing blocks()
 
@@ -424,9 +424,11 @@ def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=No
     tolerance_street : float
         tolerance in snapping to street network (by how much could be street segment extended).
     tessellation : GeoDataFrame (default None)
-        GeoDataFrame containing morphological tessellation
+        GeoDataFrame containing morphological tessellation. If edge is not passed it will be used as edge.
     tolerance_edge : float (default None)
         tolerance in snapping to edge of tessellated area (by how much could be street segment extended).
+    edge : Polygon
+        edge of area covered by morphological tessellation (same as `limit` in :py:func:`momepy.tessellation`)
 
     Returns
     -------
@@ -577,6 +579,8 @@ def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=No
     if tessellation is not None:
         print('Dissolving tesselation...')
         geometry = tessellation.geometry.unary_union.boundary
+    if edge is not None:
+        geometry = edge.boundary
 
     print('Snapping...')
     # iterating over each street segment
@@ -605,22 +609,22 @@ def snap_street_network_edge(edges, buildings, tolerance_street, tessellation=No
         # start connected, extend  end
         elif first and not second:
             if extend_line(tolerance_street, idx) is False:
-                if tessellation is not None:
+                if geometry is not None:
                     extend_line_edge(tolerance_edge, idx)
         # end connected, extend start
         elif not first and second:
             l_coords.reverse()
             if extend_line(tolerance_street, idx) is False:
-                if tessellation is not None:
+                if geometry is not None:
                     extend_line_edge(tolerance_edge, idx)
         # unconnected, extend both ends
         elif not first and not second:
             if extend_line(tolerance_street, idx) is False:
-                if tessellation is not None:
+                if geometry is not None:
                     extend_line_edge(tolerance_edge, idx)
             l_coords.reverse()
             if extend_line(tolerance_street, idx) is False:
-                if tessellation is not None:
+                if geometry is not None:
                     extend_line_edge(tolerance_edge, idx)
         else:
             print('Something went wrong.')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,5 +77,8 @@ class TestUtils:
     def test_snap_street_network_edge(self):
         snapped = mm.snap_street_network_edge(self.df_streets, self.df_buildings, 20, self.df_tessellation, 70)
         snapped_nonedge = mm.snap_street_network_edge(self.df_streets, self.df_buildings, 20)
+        snapped_edge = mm.snap_street_network_edge(self.df_streets, self.df_buildings, 20,
+                                                   tolerance_edge=70, edge=mm.buffered_limit(self.df_buildings, buffer=50))
         assert sum(snapped.geometry.length) == 5980.041004739525
+        assert sum(snapped_edge.geometry.length) == 5980.718889937014
         assert sum(snapped_nonedge.geometry.length) < 5980.041004739525


### PR DESCRIPTION
Dissolve part of `snap_street_network_edge` might not be necessary as `limit` in `tessellation` is basically the same geometry we need. This PR allows passing it directly.