### PR TITLE
ENH: allow LineString input in tessellation() to get proximity bands

### DIFF
--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -308,25 +308,26 @@ def _queen_corners(tessellation, sensitivity, sindex):
 
 def tessellation(gdf, unique_id, limit, shrink=0.4, segment=0.5, queen_corners=False, sensitivity=2):
     """
-    Generate morphological tessellation around given buildings.
+    Generate morphological tessellation around given buildings or proximity bands around given
+    street network.
 
     Parameters
     ----------
     gdf : GeoDataFrame
-        GeoDataFrame containing building footprints
+        GeoDataFrame containing building footprints or street network
     unique_id : str
         name of the column with unique id
     limit : MultiPolygon or Polygon
         MultiPolygon or Polygon defining the study area limiting tessellation (otherwise it could go to infinity).
     shrink : float (default 0.4)
-        distance for negative buffer to generate space between adjacent buildings.
+        distance for negative buffer to generate space between adjacent polygons (if geometry type of gdf is (Multi)Polygon).
     segment : float (default 0.5)
-        maximum distance between points on Polygon after discretisation
+        maximum distance between points after discretisation
 
     Returns
     -------
     GeoDataFrame
-        GeoDataFrame of morphological tessellation with the unique id based on original buildings.
+        GeoDataFrame tessellation with the unique id based on original gdf.
 
     Examples
     --------

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -80,7 +80,10 @@ def _point_array(objects, unique_id):
     points = []
     ids = []
     for idx, row in tqdm(objects.iterrows(), total=objects.shape[0]):
-        poly_ext = row['geometry'].boundary
+        if row['geometry'].type in ['Polygon', 'MultiPolygon']:
+            poly_ext = row['geometry'].boundary
+        else:
+            poly_ext = row['geometry']
         if poly_ext is not None:
             if poly_ext.type == 'MultiLineString':
                 for line in poly_ext:
@@ -358,8 +361,9 @@ def tessellation(gdf, unique_id, limit, shrink=0.4, segment=0.5, queen_corners=F
     centre = _get_centre(objects)
     objects['geometry'] = objects['geometry'].translate(xoff=-centre[0], yoff=-centre[1])
 
+    polys = ['Polygon', 'MultiPolygon']
     print('Bufferring geometry...')
-    objects['geometry'] = objects.geometry.apply(lambda g: g.buffer(-shrink, cap_style=2, join_style=2))
+    objects['geometry'] = objects.geometry.apply(lambda g: g.buffer(-shrink, cap_style=2, join_style=2) if g.type in polys else g)
 
     print('Converting multipart geometry to singlepart...')
     objects = objects.explode()

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -17,6 +17,8 @@ class TestElements:
     def test_tessellation(self):
         tessellation = mm.tessellation(self.df_buildings, 'uID', self.limit, segment=2)
         assert len(tessellation) == len(self.df_tessellation)
+        bands = mm.tessellation(self.df_streets, 'nID', mm.buffered_limit(self.df_streets, 50), segment=5)
+        assert len(bands) == len(self.df_streets)
         queen_corners = mm.tessellation(self.df_buildings, 'uID', self.limit, segment=2, queen_corners=True)
         w = libpysal.weights.Queen.from_dataframe(queen_corners)
         assert w.neighbors[14] == [35, 36, 13, 15, 26, 27, 28, 30, 31]


### PR DESCRIPTION
Allow (Multi)LineString input in `tessellation()`. Using street network as an input, one can generate proximity bands as in [Araldi & Fusco (2019)](https://journals.sagepub.com/doi/10.1177/2399808319832612). 