### PR TITLE
BUG: node_density W.neighbors is array

### DIFF
--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -433,7 +433,7 @@ def node_density(left, right, spatial_weights, weighted=False, node_degree=None,
     # iterating over rows one by one
     for index, row in tqdm(left.iterrows(), total=left.shape[0]):
 
-        neighbours = spatial_weights.neighbors[index].copy()
+        neighbours = list(spatial_weights.neighbors[index])
         neighbours.append(index)
         if weighted:
             neighbour_nodes = left.iloc[neighbours]

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -91,8 +91,10 @@ class TestIntensity:
         sw = mm.sw_high(k=3, weights=W)
         density = mm.node_density(nodes, edges, sw)
         weighted = mm.node_density(nodes, edges, sw, weighted=True, node_degree='degree')
+        array = mm.node_density(nodes, edges, W)
         assert density.mean() == 0.012690163074599968
         assert weighted.mean() == 0.023207675994368446
+        assert array.mean() == 0.008554067995928158
 
     def test_density(self):
         sw = mm.sw_high(k=3, gdf=self.df_tessellation, ids='uID')


### PR DESCRIPTION
For some reason, `W.neighbors` is a list if done using libpysal and array after export from networkx.