### PR TITLE
ENH: Multiple centrality assessment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ install:
   - source activate test
   - if [ "$DEV" ]; then pip install git+https://github.com/geopandas/geopandas.git; fi
   - if [ "$DEV" ]; then pip install git+https://github.com/pysal/libpysal.git; fi
+  - if [ "$DEV" ]; then pip install git+https://github.com/networkx/networkx.git; fi
+
   - python setup.py install
   - conda list
   - black --check .

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -96,17 +96,21 @@ graph
 .. autosummary::
    :toctree: generated/
 
+   betweenness_centrality
    cds_length
    clustering
    cyclomatic
    edge_node_ratio
    gamma
-   local_closeness
+   global_closeness_centrality
+   local_closeness_centrality
    mean_node_degree
    mean_node_dist
+   mean_nodes
    meshedness
    node_degree
    proportion
+   straightness_centrality
    subgraph
 
 diversity

--- a/momepy/graph.py
+++ b/momepy/graph.py
@@ -572,7 +572,7 @@ def clustering(graph, name="cluster"):
     return netx
 
 
-def _closeness_centrality(G, u=None, distance=None, wf_improved=True, len_graph=None):
+def _closeness_centrality(G, u=None, length=None, wf_improved=True, len_graph=None):
     r"""Compute closeness centrality for nodes. Slight adaptation of networkx
     `closeness_centrality` to allow normalisation for local closeness.
     Adapted script used in networkx.
@@ -633,12 +633,12 @@ def _closeness_centrality(G, u=None, distance=None, wf_improved=True, len_graph=
        Cambridge University Press.
     """
 
-    if distance is not None:
+    if length is not None:
         import functools
 
         # use Dijkstra's algorithm with specified attribute as edge weight
         path_length = functools.partial(
-            nx.single_source_dijkstra_path_length, weight=distance
+            nx.single_source_dijkstra_path_length, weight=length
         )
     else:
         path_length = nx.single_source_shortest_path_length
@@ -659,8 +659,8 @@ def _closeness_centrality(G, u=None, distance=None, wf_improved=True, len_graph=
     return closeness_centrality[u]
 
 
-def local_closeness(
-    graph, radius=5, name="closeness", distance=None, closeness_distance=None
+def local_closeness_centrality(
+    graph, radius=5, name="closeness", distance=None, length=None
 ):
     """
     Calculates local closeness for each node based on the defined distance.
@@ -685,7 +685,7 @@ def local_closeness(
         Use specified edge data key as distance.
         For example, setting distance=’weight’ will use the edge weight to
         measure the distance from the node n.
-    closeness_distance : str, optional
+    length : str, optional
       Use the specified edge attribute as the edge distance in shortest
       path calculations in closeness centrality algorithm
 
@@ -701,7 +701,7 @@ def local_closeness(
 
     Examples
     --------
-    >>> network_graph = mm.local_closeness(network_graph, radius=400, distance='edge_length')
+    >>> network_graph = mm.local_closeness_centrality(network_graph, radius=400, distance='edge_length')
 
     """
     netx = graph.copy()
@@ -711,13 +711,13 @@ def local_closeness(
             netx, n, radius=radius, undirected=True, distance=distance
         )  # define subgraph of steps=radius
         netx.nodes[n][name] = _closeness_centrality(
-            sub, n, distance=closeness_distance, len_graph=lengraph
+            sub, n, length=length, len_graph=lengraph
         )
 
     return netx
 
 
-def global_closeness(graph, name="closeness", length="mm_len", **kwargs):
+def global_closeness_centrality(graph, name="closeness", length="mm_len", **kwargs):
     """
     Calculates the closeness centrality for nodes.
 
@@ -745,7 +745,7 @@ def global_closeness(graph, name="closeness", length="mm_len", **kwargs):
 
     Examples
     --------
-    >>> network_graph = mm.global_closeness(network_graph)
+    >>> network_graph = mm.global_closeness_centrality(network_graph)
     """
     netx = graph.copy()
 
@@ -911,7 +911,7 @@ def subgraph(
     edge_node_ratio=True,
     gamma=True,
     local_closeness=True,
-    closeness_distance=None,
+    closeness_length=None,
 ):
     """
     Calculates all subgraph-based characters.
@@ -954,7 +954,7 @@ def subgraph(
         Calculate gamma index (True/False)
     local_closeness : bool, default True
         Calculate local closeness centrality (True/False)
-    closeness_distance : str, optional
+    closeness_length : str, optional
       Use the specified edge attribute as the edge distance in shortest
       path calculations in closeness centrality algorithm
 
@@ -1012,7 +1012,7 @@ def subgraph(
         if local_closeness:
             lengraph = len(netx)
             netx.nodes[n]["local_closeness"] = _closeness_centrality(
-                sub, n, distance=closeness_distance, len_graph=lengraph
+                sub, n, length=closeness_length, len_graph=lengraph
             )
 
     return netx

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -72,14 +72,59 @@ class TestGraph:
         assert net.nodes[(1603650.450422848, 6464368.600601688)]["gamma"] == check
 
     def test_local_closeness(self):
-        net = mm.local_closeness(self.network)
+        net = mm.local_closeness_centrality(self.network)
         check = 0.27557319223985893
         assert net.nodes[(1603650.450422848, 6464368.600601688)]["closeness"] == check
+        net2 = mm.local_closeness_centrality(self.network, length="mm_len")
+        check2 = 0.0015544070362478774
+        assert net2.nodes[(1603650.450422848, 6464368.600601688)]["closeness"] == check2
 
-    def test_local_closeness_distance(self):
-        net = mm.local_closeness(self.network, closeness_distance="mm_len")
-        check = 0.0015544070362478774
+    def test_global_closeness_centrality(self):
+        net = mm.global_closeness_centrality(self.network, length="mm_len")
+        check = 0.0016066095164175716
         assert net.nodes[(1603650.450422848, 6464368.600601688)]["closeness"] == check
+
+    def test_betweenness_centrality(self):
+        net = mm.betweenness_centrality(self.network)
+        net2 = mm.betweenness_centrality(self.network, mode="edges")
+        with pytest.raises(ValueError):
+            mm.betweenness_centrality(self.network, mode="nonexistent")
+        node = 0.15806878306878305
+        edge = 0.20320197044334976
+        assert net.nodes[(1603650.450422848, 6464368.600601688)]["betweenness"] == node
+        assert (
+            net2.edges[
+                (1603226.9576840235, 6464160.158361825),
+                (1603039.9632033885, 6464087.491175889),
+                8,
+            ]["betweenness"]
+            == edge
+        )
+
+    def test_straightness_centrality(self):
+        net = mm.straightness_centrality(self.network)
+        net2 = mm.straightness_centrality(
+            self.network, normalized=False, name="nonnorm"
+        )
+        check = 0.8574045143712158
+        nonnorm = 0.8574045143712158
+        assert (
+            net.nodes[(1603650.450422848, 6464368.600601688)]["straightness"] == check
+        )
+        assert net2.nodes[(1603650.450422848, 6464368.600601688)]["nonnorm"] == nonnorm
+
+    def test_mean_nodes(self):
+        net = mm.straightness_centrality(self.network)
+        mm.mean_nodes(net, "straightness")
+        edge = 0.8777302256084243
+        assert (
+            net.edges[
+                (1603226.9576840235, 6464160.158361825),
+                (1603039.9632033885, 6464087.491175889),
+                8,
+            ]["straightness"]
+            == edge
+        )
 
     def test_clustering(self):
         net = mm.clustering(self.network)


### PR DESCRIPTION
Add Betweenness, straightness and global closeness centrality. Betweenness can be calculated on both nodes and edges. Rest on nodes, could be approximated on edges using `mean_nodes`.