### PR TITLE
PERF: set unique_id as index for faster indexing

### DIFF
--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -414,13 +414,14 @@ def alignment(gdf, spatial_weights, unique_id, orientations):
         orientations = "mm_o"
 
     print("Calculating alignments...")
+    data = gdf.set_index(unique_id)
 
     # iterating over rows one by one
-    for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
+    for index, row in tqdm(data.iterrows(), total=data.shape[0]):
 
-        neighbours = spatial_weights.neighbors[row[unique_id]].copy()
+        neighbours = spatial_weights.neighbors[index].copy()
         if neighbours:
-            orientation = gdf.loc[gdf[unique_id].isin(neighbours)][orientations]
+            orientation = data.loc[neighbours][orientations]
             deviations = abs(orientation - row[orientations])
 
             results_list.append(statistics.mean(deviations))
@@ -472,11 +473,12 @@ def neighbour_distance(gdf, spatial_weights, unique_id):
     results_list = []
 
     print("Calculating distances...")
+    data = gdf.set_index(unique_id)
 
     # iterating over rows one by one
-    for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
-        neighbours = spatial_weights.neighbors[row[unique_id]]
-        building_neighbours = gdf.loc[gdf[unique_id].isin(neighbours)]
+    for index, row in tqdm(data.iterrows(), total=data.shape[0]):
+        neighbours = spatial_weights.neighbors[index]
+        building_neighbours = data.loc[neighbours]
         if len(building_neighbours) > 0:
             results_list.append(
                 np.mean(building_neighbours.geometry.distance(row["geometry"]))

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -280,20 +280,22 @@ def blocks_count(gdf, block_id, spatial_weights, unique_id, weighted=True):
     """
     # define empty list for results
     results_list = []
-    gdf = gdf.copy()
+    data = gdf.copy()
     if not isinstance(block_id, str):
-        gdf["mm_bid"] = block_id
+        data["mm_bid"] = block_id
         block_id = "mm_bid"
+
+    data = data.set_index(unique_id)
 
     print("Calculating blocks...")
 
-    for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
-        neighbours = spatial_weights.neighbors[row[unique_id]].copy()
+    for index, row in tqdm(data.iterrows(), total=data.shape[0]):
+        neighbours = spatial_weights.neighbors[index].copy()
         if neighbours:
-            neighbours.append(row[unique_id])
+            neighbours.append(index)
         else:
             neighbours = row[unique_id]
-        vicinity = gdf.loc[gdf[unique_id].isin(neighbours)]
+        vicinity = data.loc[neighbours]
 
         if weighted is True:
             results_list.append(
@@ -544,25 +546,26 @@ def density(gdf, values, spatial_weights, unique_id, areas=None):
     """
     # define empty list for results
     results_list = []
-    gdf = gdf.copy()
+    data = gdf.copy()
 
     print("Calculating gross density...")
     if values is not None:
         if not isinstance(values, str):
-            gdf["mm_v"] = values
+            data["mm_v"] = values
             values = "mm_v"
     if areas is not None:
         if not isinstance(areas, str):
-            gdf["mm_a"] = areas
+            data["mm_a"] = areas
             areas = "mm_a"
+    data = data.set_index(unique_id)
     # iterating over rows one by one
-    for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
-        neighbours = spatial_weights.neighbors[row[unique_id]].copy()
+    for index, row in tqdm(data.iterrows(), total=data.shape[0]):
+        neighbours = spatial_weights.neighbors[index].copy()
         if neighbours:
-            neighbours.append(row[unique_id])
+            neighbours.append(index)
         else:
-            neighbours = row[unique_id]
-        subset = gdf.loc[gdf[unique_id].isin(neighbours)]
+            neighbours = index
+        subset = data.loc[neighbours]
         values_list = subset[values]
         if areas is not None:
             areas_list = subset[areas]

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from momepy.shape import _make_circle
 from momepy import sw_high
+from pytest import approx
 
 
 class TestDimensions:
@@ -156,10 +157,10 @@ class TestDimensions:
                 unique_id="uID",
                 mode="nonexistent",
             )
-        assert self.df_tessellation["mesh_ar"][0] == 249.50382416977067
-        assert self.df_tessellation["mesh_array"][0] == 2623.996266097268
-        assert self.df_tessellation["mesh_id"][38] == 2250.2241176070806
-        assert self.df_tessellation["mesh_iq"][38] == 2118.6091427330666
+        assert self.df_tessellation["mesh_ar"][0] == approx(249.503, rel=1e-3)
+        assert self.df_tessellation["mesh_array"][0] == approx(2623.996, rel=1e-3)
+        assert self.df_tessellation["mesh_id"][38] == approx(2250.224, rel=1e-3)
+        assert self.df_tessellation["mesh_iq"][38] == approx(2118.609, rel=1e-3)
 
     def test_street_profile(self):
         results = mm.street_profile(
@@ -187,13 +188,13 @@ class TestDimensions:
     def test_weighted_character_sw(self):
         sw = sw_high(k=3, gdf=self.df_tessellation, ids="uID")
         weighted = mm.weighted_character(self.df_buildings, "height", sw, "uID")
-        assert weighted[38] == 18.301521351817303
+        assert weighted[38] == approx(18.301, rel=1e-3)
 
     def test_weighted_character_area(self):
         self.df_buildings["area"] = self.df_buildings.geometry.area
         sw = sw_high(k=3, gdf=self.df_tessellation, ids="uID")
         weighted = mm.weighted_character(self.df_buildings, "height", sw, "uID", "area")
-        assert weighted[38] == 18.301521351817303
+        assert weighted[38] == approx(18.301, rel=1e-3)
 
     def test_weighted_character_array(self):
         area = self.df_buildings.geometry.area
@@ -201,12 +202,12 @@ class TestDimensions:
         weighted = mm.weighted_character(
             self.df_buildings, self.df_buildings.height, sw, "uID", area
         )
-        assert weighted[38] == 18.301521351817303
+        assert weighted[38] == approx(18.301, rel=1e-3)
 
     def test_covered_area(self):
         sw = sw_high(gdf=self.df_tessellation, k=1, ids="uID")
         covered_sw = mm.covered_area(self.df_tessellation, sw, "uID")
-        assert covered_sw[0] == 24115.667218339422
+        assert covered_sw[0] == approx(24115.667, rel=1e-3)
 
     def test_wall(self):
         sw = sw_high(gdf=self.df_buildings, k=1)

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -5,6 +5,7 @@ import numpy as np
 from momepy import sw_high
 
 import pytest
+from pytest import approx
 
 
 class TestDiversity:
@@ -20,16 +21,16 @@ class TestDiversity:
 
     def test_rng(self):
         full_sw = mm.rng(self.df_tessellation, "area", self.sw, "uID")
-        assert full_sw[0] == 8255.372874447059
+        assert full_sw[0] == approx(8255.372, rel=1e-3)
         area = self.df_tessellation["area"]
         full2 = mm.rng(self.df_tessellation, area, self.sw, "uID")
-        assert full2[0] == 8255.372874447059
+        assert full2[0] == approx(8255.372, rel=1e-3)
         limit = mm.rng(self.df_tessellation, "area", self.sw, "uID", rng=(10, 90))
-        assert limit[0] == 4122.139212736442
+        assert limit[0] == approx(4122.139, rel=1e-3)
 
     def test_theil(self):
         full_sw = mm.theil(self.df_tessellation, "area", self.sw, "uID")
-        assert full_sw[0] == 0.25744684318865324
+        assert full_sw[0] == approx(0.25744684)
         limit = mm.theil(
             self.df_tessellation,
             self.df_tessellation.area,
@@ -37,7 +38,7 @@ class TestDiversity:
             "uID",
             rng=(10, 90),
         )
-        assert limit[0] == 0.13302952097969373
+        assert limit[0] == approx(0.1330295)
 
     def test_simpson(self):
         ht_sw = mm.simpson(self.df_tessellation, "area", self.sw, "uID")
@@ -58,9 +59,9 @@ class TestDiversity:
 
     def test_gini(self):
         full_sw = mm.gini(self.df_tessellation, "area", self.sw, "uID")
-        assert full_sw[0] == 0.39453880039926703
+        assert full_sw[0] == approx(0.3945388)
         limit = mm.gini(self.df_tessellation, "area", self.sw, "uID", rng=(10, 90))
-        assert limit[0] == 0.28532814172859305
+        assert limit[0] == approx(0.28532814)
         self.df_tessellation["negative"] = (
             self.df_tessellation.area - self.df_tessellation.area.mean()
         )

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -5,6 +5,8 @@ from libpysal.weights import Queen
 
 import pytest
 
+from pytest import approx
+
 
 class TestIntensity:
     def setup_method(self):
@@ -183,6 +185,6 @@ class TestIntensity:
         dens2 = mm.density(
             self.df_tessellation, self.df_buildings["fl_area"], sw, "uID"
         )
-        check = 1.6615871155383324
-        assert dens.mean() == check
-        assert dens2.mean() == check
+        check = 1.661587
+        assert dens.mean() == approx(check)
+        assert dens2.mean() == approx(check)


### PR DESCRIPTION
Avoid `isin()` search where unique_id can be set as index. It provides significant performance gain.