### PR TITLE
BUG: straightness centrality of disconnected node

### DIFF
--- a/momepy/graph.py
+++ b/momepy/graph.py
@@ -993,8 +993,11 @@ def _straightness_centrality(G, weight, normalized=True):
             straightness_centrality[n] = straightness * (1.0 / (len(G) - 1.0))
             # normalize to number of nodes-1 in connected part
             if normalized:
-                s = (len(G) - 1.0) / (len(sp) - 1.0)
-                straightness_centrality[n] *= s
+                if len(sp) > 1:
+                    s = (len(G) - 1.0) / (len(sp) - 1.0)
+                    straightness_centrality[n] *= s
+                else:
+                    straightness_centrality[n] = 0
         else:
             straightness_centrality[n] = 0.0
     return straightness_centrality

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -125,12 +125,18 @@ class TestGraph:
         net2 = mm.straightness_centrality(
             self.network, normalized=False, name="nonnorm"
         )
+        G = self.network.copy()
+        G.add_node(1)
+        net3 = mm.straightness_centrality(G)
         check = 0.8574045143712158
         nonnorm = 0.8574045143712158
         assert (
             net.nodes[(1603650.450422848, 6464368.600601688)]["straightness"] == check
         )
         assert net2.nodes[(1603650.450422848, 6464368.600601688)]["nonnorm"] == nonnorm
+        assert (
+            net3.nodes[(1603650.450422848, 6464368.600601688)]["straightness"] == check
+        )
 
     def test_local_straightness_centrality(self):
         net = mm.local_straightness_centrality(self.network)


### PR DESCRIPTION
Straightness centrality of disconnected node currently raises error due to division by zero. Fixed.