### PR TITLE
BUG: encoding issue when installong from source on win

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ for item in os.listdir("momepy/datasets"):
         elif item.endswith(".gpkg"):
             data_files.append(os.path.join("datasets", item))
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
Fixing following issue with installing under windows

```
 ERROR: Command errored out with exit status 1:
     command: 'C:\Users\wlb17212\AppData\Local\Continuum\anaconda3\envs\clustering\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\wlb17212\\AppData\\Local\\Temp\\pip-req-build-2_cxjmyi\\setup.py'"'"'; __file__='"'"'C:\\Users\\wlb17212\\AppData\\Local\\Temp\\pip-req-build-2_cxjmyi\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: C:\Users\wlb17212\AppData\Local\Temp\pip-req-build-2_cxjmyi\
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\wlb17212\AppData\Local\Temp\pip-req-build-2_cxjmyi\setup.py", line 20, in <module>
        long_description = fh.read()
      File "C:\Users\wlb17212\AppData\Local\Continuum\anaconda3\envs\clustering\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1222: character maps to <undefined>
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```