### PR TITLE
BUG: generating angular graph with non-default index

### DIFF
--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -151,16 +151,16 @@ def _generate_dual(G, gdf_network, fields):
     sw = libpysal.weights.Queen.from_dataframe(gdf_network)
     gdf_network["mm_cent"] = gdf_network.geometry.centroid
 
-    for index, row in gdf_network.iterrows():
+    for i, (index, row) in enumerate(gdf_network.iterrows()):
         centroid = (row.mm_cent.x, row.mm_cent.y)
         data = [row[f] for f in fields]
         attributes = dict(zip(fields, data))
         G.add_node(centroid, **attributes)
 
-        if sw.cardinalities[index] > 0:
-            for n in sw.neighbors[index]:
+        if sw.cardinalities[i] > 0:
+            for n in sw.neighbors[i]:
                 start = centroid
-                end = list(gdf_network.loc[n, "mm_cent"].coords)[0]
+                end = list(gdf_network.iloc[n]["mm_cent"].coords)[0]
                 p0 = row.geometry.coords[0]
                 p1 = row.geometry.coords[-1]
                 p2 = gdf_network.iloc[n]["geometry"].coords[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,11 @@ class TestUtils:
         dual = mm.gdf_to_nx(self.df_streets, approach="dual")
         assert dual.number_of_nodes() == 35
         assert dual.number_of_edges() == 148
+        self.df_streets["ix"] = np.arange(0, len(self.df_streets) * 2, 2)
+        self.df_streets.set_index("ix", inplace=True)
+        dual2 = mm.gdf_to_nx(self.df_streets, approach="dual")
+        assert dual2.number_of_nodes() == 35
+        assert dual2.number_of_edges() == 148
         with pytest.raises(ValueError):
             mm.gdf_to_nx(self.df_streets, approach="nonexistent")
 


### PR DESCRIPTION
`_generate_dual()` within `gdf_to_nx()` expected index to be consecutive integer 0-n. That is no longer true and every kind of index should be okay.