### PR TITLE
BUG: import of `_longest_axis`

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -282,6 +282,12 @@ class CourtyardArea:
         )
 
 
+# calculate the radius of circumcircle
+def _longest_axis(points):
+    circ = _make_circle(points)
+    return circ[2] * 2
+
+
 class LongestAxisLength:
     """
     Calculates the length of the longest axis of object.
@@ -315,14 +321,9 @@ class LongestAxisLength:
     def __init__(self, gdf):
         self.gdf = gdf
         self.lal = gdf.apply(
-            lambda row: self._longest_axis(row.geometry.convex_hull.exterior.coords),
+            lambda row: _longest_axis(row.geometry.convex_hull.exterior.coords),
             axis=1,
         )
-
-    # calculate the radius of circumcircle
-    def _longest_axis(self, points):
-        circ = _make_circle(points)
-        return circ[2] * 2
 
 
 class AverageCharacter:

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -186,6 +186,8 @@ class TestShape:
         assert self.df_buildings["elo"][0] == check
 
     def test_CentroidCorners(self):
+        from shapely.geometry import Point
+        self.df_buildings.loc[144] = [145, Point(0, 0).buffer(10), 0, 0]
         cc = mm.CentroidCorners(self.df_buildings)
         self.df_buildings["ccd"] = cc.mean
         self.df_buildings["ccddev"] = cc.std

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -186,7 +186,6 @@ class TestShape:
         assert self.df_buildings["elo"][0] == check
 
     def test_CentroidCorners(self):
-        from shapely.geometry import Point
         self.df_buildings.loc[144] = [145, Point(0, 0).buffer(10), 0, 0]
         cc = mm.CentroidCorners(self.df_buildings)
         self.df_buildings["ccd"] = cc.mean


### PR DESCRIPTION
Fixes #108 

Move `_longest_axis` out of the class so it is accessible by other classes as well.  Added test to cover the import of `_longest_axis` in `CentroidCorners`.