### PR TITLE
BUG: AreaRatio resets index

### DIFF
--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -118,7 +118,7 @@ class AreaRatio:
         ].copy()  # keeping only necessary columns
         look_for.rename(index=str, columns={right_areas: "lf_area"}, inplace=True)
         objects_merged = left[[left_unique_id, left_areas]].merge(
-            look_for, left_on=left_unique_id, right_on=right_unique_id
+            look_for, left_on=left_unique_id, right_on=right_unique_id, how='left'
         )
         objects_merged.index = left.index
 

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -120,6 +120,7 @@ class AreaRatio:
         objects_merged = left[[left_unique_id, left_areas]].merge(
             look_for, left_on=left_unique_id, right_on=right_unique_id
         )
+        objects_merged.index = left.index
 
         self.series = objects_merged["lf_area"] / objects_merged[left_areas]
 

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -118,7 +118,7 @@ class AreaRatio:
         ].copy()  # keeping only necessary columns
         look_for.rename(index=str, columns={right_areas: "lf_area"}, inplace=True)
         objects_merged = left[[left_unique_id, left_areas]].merge(
-            look_for, left_on=left_unique_id, right_on=right_unique_id, how='left'
+            look_for, left_on=left_unique_id, right_on=right_unique_id, how="left"
         )
         objects_merged.index = left.index
 

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -70,6 +70,10 @@ class TestIntensity:
                 "area",
                 right_unique_id="uID",
             )
+        car_sel = mm.AreaRatio(
+            self.df_tessellation.iloc[10:20], self.df_buildings, "area", "area", "uID"
+        ).series
+        assert (car_sel.index == self.df_tessellation.iloc[10:20].index).all()
 
     def test_Count(self):
         eib = mm.Count(self.blocks, self.df_buildings, "bID", "bID").series


### PR DESCRIPTION
`AreaRatio` does not return resulting Series with the original index but reset one. That should be fixed now.