### PR TITLE
BUG: return np.nan if feature not in spatial_weights

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -399,26 +399,29 @@ class AverageCharacter:
 
         results_list = []
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
-            neighbours = spatial_weights.neighbors[index].copy()
-            if neighbours:
-                neighbours.append(index)
+            if index in spatial_weights.neighbors.keys():
+                neighbours = spatial_weights.neighbors[index].copy()
+                if neighbours:
+                    neighbours.append(index)
+                else:
+                    neighbours = [index]
+
+                values_list = data.loc[neighbours][values]
+
+                if rng:
+                    from momepy import limit_range
+
+                    values_list = limit_range(values_list, rng=rng)
+                if mode == "mean":
+                    results_list.append(np.mean(values_list))
+                elif mode == "median":
+                    results_list.append(np.median(values_list))
+                elif mode == "mode":
+                    results_list.append(sp.stats.mode(values_list)[0][0])
+                else:
+                    raise ValueError("{} is not supported as mode.".format(mode))
             else:
-                neighbours = [index]
-
-            values_list = data.loc[neighbours][values]
-
-            if rng:
-                from momepy import limit_range
-
-                values_list = limit_range(values_list, rng=rng)
-            if mode == "mean":
-                results_list.append(np.mean(values_list))
-            elif mode == "median":
-                results_list.append(np.median(values_list))
-            elif mode == "mode":
-                results_list.append(sp.stats.mode(values_list)[0][0])
-            else:
-                raise ValueError("{} is not supported as mode.".format(mode))
+                results_list.append(np.nan)
 
         self.series = pd.Series(results_list, index=gdf.index)
 
@@ -764,16 +767,19 @@ class WeightedCharacter:
 
         results_list = []
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
-            neighbours = spatial_weights.neighbors[index].copy()
-            if neighbours:
-                neighbours.append(index)
-            else:
-                neighbours = [index]
+            if index in spatial_weights.neighbors.keys():
+                neighbours = spatial_weights.neighbors[index].copy()
+                if neighbours:
+                    neighbours.append(index)
+                else:
+                    neighbours = [index]
 
-            subset = data.loc[neighbours]
-            results_list.append(
-                (sum(subset[values] * subset[areas])) / (sum(subset[areas]))
-            )
+                subset = data.loc[neighbours]
+                results_list.append(
+                    (sum(subset[values] * subset[areas])) / (sum(subset[areas]))
+                )
+            else:
+                results_list.append(np.nan)
 
         self.series = pd.Series(results_list, index=gdf.index)
 
@@ -824,14 +830,17 @@ class CoveredArea:
 
         results_list = []
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
-            neighbours = spatial_weights.neighbors[index].copy()
-            if neighbours:
-                neighbours.append(index)
-            else:
-                neighbours = [index]
+            if index in spatial_weights.neighbors.keys():
+                neighbours = spatial_weights.neighbors[index].copy()
+                if neighbours:
+                    neighbours.append(index)
+                else:
+                    neighbours = [index]
 
-            areas = data.loc[neighbours].geometry.area
-            results_list.append(sum(areas))
+                areas = data.loc[neighbours].geometry.area
+                results_list.append(sum(areas))
+            else:
+                results_list.append(np.nan)
 
         self.series = pd.Series(results_list, index=gdf.index)
 

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -950,6 +950,6 @@ class Neighbors:
                 else:
                     neighbours.append(spatial_weights.cardinalities[row[unique_id]])
             else:
-                neighbours.append(0)
+                neighbours.append(np.nan)
 
         self.series = pd.Series(neighbours, index=gdf.index)

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -464,12 +464,9 @@ class Reached:
             if spatial_weights is None:
                 ids = [row[left_id]]
             else:
-                if index in spatial_weights.neighbors.keys():
-                    neighbours = list(spatial_weights.neighbors[index])
-                    neighbours.append(index)
-                    ids = left.iloc[neighbours][left_id]
-                else:
-                    ids = []
+                neighbours = list(spatial_weights.neighbors[index])
+                neighbours.append(index)
+                ids = left.iloc[neighbours][left_id]
             if mode == "count":
                 counts = []
                 for nid in ids:

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -584,7 +584,7 @@ def network_false_nodes(gdf):
             import warnings
 
             warnings.warn(
-                "An exception during merging occured."
+                "An exception during merging occured. "
                 "Lines at point [{x}, {y}] were not merged.".format(
                     x=point.x, y=point.y
                 )

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -151,6 +151,17 @@ class TestDimensions:
         assert self.df_tessellation["mesh_array"][0] == approx(2623.996, rel=1e-3)
         assert self.df_tessellation["mesh_id"][38] == approx(2250.224, rel=1e-3)
         assert self.df_tessellation["mesh_iq"][38] == approx(2118.609, rel=1e-3)
+        sw_drop = sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.AverageCharacter(
+                self.df_tessellation,
+                values="area",
+                spatial_weights=sw_drop,
+                unique_id="uID",
+            )
+            .series.isna()
+            .any()
+        )
 
     def test_StreetProfile(self):
         results = mm.StreetProfile(self.df_streets, self.df_buildings, heights="height")
@@ -196,10 +207,19 @@ class TestDimensions:
         ).series
         assert weighted[38] == approx(18.301, rel=1e-3)
 
+        sw_drop = sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.WeightedCharacter(self.df_buildings, "height", sw_drop, "uID")
+            .series.isna()
+            .any()
+        )
+
     def test_CoveredArea(self):
         sw = sw_high(gdf=self.df_tessellation, k=1, ids="uID")
         covered_sw = mm.CoveredArea(self.df_tessellation, sw, "uID").series
         assert covered_sw[0] == approx(24115.667, rel=1e-3)
+        sw_drop = sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
+        assert mm.CoveredArea(self.df_tessellation, sw_drop, "uID").series.isna().any()
 
     def test_PerimeterWall(self):
         sw = sw_high(gdf=self.df_buildings, k=1)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -103,6 +103,12 @@ class TestDistribution:
             self.df_buildings, sw, "uID", self.df_buildings["orient"]
         ).series
         assert self.df_buildings["align_sw"][0] == 18.299481296455237
+        sw_drop = Queen.from_dataframe(self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.Alignment(self.df_buildings, sw_drop, "uID", self.df_buildings["orient"])
+            .series.isna()
+            .any()
+        )
 
     def test_NeighborDistance(self):
         sw = Queen.from_dataframe(self.df_tessellation, ids="uID")
@@ -132,6 +138,12 @@ class TestDistribution:
         check = 29.305457092042744
         assert self.df_buildings["m_dist_sw"][0] == check
         assert self.df_buildings["m_dist"][0] == check
+        sw_drop = Queen.from_dataframe(self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.MeanInterbuildingDistance(self.df_buildings, sw_drop, "uID")
+            .series.isna()
+            .any()
+        )
 
     def test_NeighboringStreetOrientationDeviation(self):
         self.df_streets["dev"] = mm.NeighboringStreetOrientationDeviation(
@@ -155,9 +167,18 @@ class TestDistribution:
         check = 0.2613824113909074
         assert self.df_buildings["adj_sw"].mean() == check
         assert self.df_buildings["adj_sw_none"].mean() == check
+        swh_drop = mm.sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.BuildingAdjacency(
+                self.df_buildings, unique_id="uID", spatial_weights_higher=swh_drop
+            )
+            .series.isna()
+            .any()
+        )
 
     def test_Neighbors(self):
         sw = Queen.from_dataframe(self.df_tessellation, ids="uID")
+        sw_drop = Queen.from_dataframe(self.df_tessellation[2:], ids="uID")
         self.df_tessellation["nei_sw"] = mm.Neighbors(
             self.df_tessellation, sw, "uID"
         ).series
@@ -168,3 +189,4 @@ class TestDistribution:
         check_w = 0.029066398893536072
         assert self.df_tessellation["nei_sw"].mean() == check
         assert self.df_tessellation["nei_wei"].mean() == check_w
+        assert mm.Neighbors(self.df_tessellation, sw_drop, "uID").series.isna().any()

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -112,6 +112,14 @@ class TestDistribution:
         check = 29.18589019096464
         assert self.df_buildings["dist_sw"][0] == check
 
+        sw_drop = Queen.from_dataframe(self.df_tessellation[:-2], ids="uID")
+        self.df_buildings["dist_sw"] = mm.NeighborDistance(
+            self.df_buildings, sw_drop, "uID"
+        ).series
+        check = 29.18589019096464
+        assert self.df_buildings["dist_sw"][0] == check
+        assert self.df_buildings["dist_sw"].isna().any()
+
     def test_MeanInterbuildingDistance(self):
         sw = Queen.from_dataframe(self.df_tessellation, ids="uID")
         swh = mm.sw_high(k=3, gdf=self.df_tessellation, ids="uID")

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -27,6 +27,7 @@ class TestDiversity:
         self.df_buildings["height"] = np.linspace(10.0, 30.0, 144)
         self.df_tessellation["area"] = mm.Area(self.df_tessellation).series
         self.sw = sw_high(k=3, gdf=self.df_tessellation, ids="uID")
+        self.sw_drop = sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
 
     def test_Range(self):
         full_sw = mm.Range(self.df_tessellation, "area", self.sw, "uID").series
@@ -38,6 +39,11 @@ class TestDiversity:
             self.df_tessellation, "area", self.sw, "uID", rng=(10, 90)
         ).series
         assert limit[0] == approx(4122.139, rel=1e-3)
+        assert (
+            mm.Range(self.df_tessellation, "area", self.sw_drop, "uID")
+            .series.isna()
+            .any()
+        )
 
     def test_Theil(self):
         full_sw = mm.Theil(self.df_tessellation, "area", self.sw, "uID").series
@@ -54,6 +60,11 @@ class TestDiversity:
             self.df_tessellation, np.zeros(len(self.df_tessellation)), self.sw, "uID"
         ).series
         assert zeros[0] == 0
+        assert (
+            mm.Theil(self.df_tessellation, "area", self.sw_drop, "uID")
+            .series.isna()
+            .any()
+        )
 
     @pytest.mark.skipif(MC_21, reason="requires mapclassify < 2.1")
     def test_Simpson(self):
@@ -72,6 +83,11 @@ class TestDiversity:
             ht_sw = mm.Simpson(
                 self.df_tessellation, "area", self.sw, "uID", binning="nonexistent"
             )
+        assert (
+            mm.Simpson(self.df_tessellation, "area", self.sw_drop, "uID")
+            .series.isna()
+            .any()
+        )
 
     def test_Gini(self):
         full_sw = mm.Gini(self.df_tessellation, "area", self.sw, "uID").series
@@ -85,3 +101,8 @@ class TestDiversity:
         )
         with pytest.raises(ValueError):
             mm.Gini(self.df_tessellation, "negative", self.sw, "uID").series
+        assert (
+            mm.Gini(self.df_tessellation, "area", self.sw_drop, "uID")
+            .series.isna()
+            .any()
+        )

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -117,6 +117,12 @@ class TestIntensity:
             count = mm.BlocksCount(
                 self.df_tessellation, "bID", sw, "uID", weighted="yes"
             )
+        sw_drop = mm.sw_high(k=5, gdf=self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.BlocksCount(self.df_tessellation, "bID", sw_drop, "uID")
+            .series.isna()
+            .any()
+        )
 
     def test_Reached(self):
         count = mm.Reached(self.df_streets, self.df_buildings, "nID", "nID").series
@@ -199,3 +205,11 @@ class TestIntensity:
         check = 1.661587
         assert dens.mean() == approx(check)
         assert dens2.mean() == approx(check)
+        sw_drop = mm.sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
+        assert (
+            mm.Density(
+                self.df_tessellation, self.df_buildings["fl_area"], sw_drop, "uID"
+            )
+            .series.isna()
+            .any()
+        )


### PR DESCRIPTION
Probably closes #130 

Instead of throwing KeyError, feature which is not present in spatial weights now gets assigned np.nan. Should fixes cases when tessellation does not match buildings and similar.