### PR TITLE
CI: pin libpysal

### DIFF
--- a/ci/travis/latest-mc.yaml
+++ b/ci/travis/latest-mc.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python
   - geopandas
-  - libpysal
+  - libpysal=4.1.1
   - networkx
   - tqdm
   - pytest


### PR DESCRIPTION
Temporarily pin libpysal to avoid failure on appveyor. libpysal 4.2.0 has encoding issue, which is being fixed in 4.2.1 but that is not on conda-forge yet.