### PR TITLE
ENH: AreaRatio for uneven number of features

### DIFF
--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -117,6 +117,7 @@ class AreaRatio:
             [right_unique_id, right_areas]
         ].copy()  # keeping only necessary columns
         look_for.rename(index=str, columns={right_areas: "lf_area"}, inplace=True)
+        look_for = look_for.groupby(right_unique_id).sum().reset_index()
         objects_merged = left[[left_unique_id, left_areas]].merge(
             look_for, left_on=left_unique_id, right_on=right_unique_id, how="left"
         )

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -74,10 +74,8 @@ class TestIntensity:
             self.df_tessellation.iloc[10:20], self.df_buildings, "area", "area", "uID"
         ).series
         assert (car_sel.index == self.df_tessellation.iloc[10:20].index).all()
-        self.blocks['area'] = self.blocks.geometry.area
-        car_block = mm.AreaRatio(
-            self.blocks, self.df_buildings, 'area', 'area', 'bID'
-        )
+        self.blocks["area"] = self.blocks.geometry.area
+        car_block = mm.AreaRatio(self.blocks, self.df_buildings, "area", "area", "bID")
         assert car_block.series.mean() == 0.2761974319698012
 
     def test_Count(self):

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -74,6 +74,11 @@ class TestIntensity:
             self.df_tessellation.iloc[10:20], self.df_buildings, "area", "area", "uID"
         ).series
         assert (car_sel.index == self.df_tessellation.iloc[10:20].index).all()
+        self.blocks['area'] = self.blocks.geometry.area
+        car_block = mm.AreaRatio(
+            self.blocks, self.df_buildings, 'area', 'area', 'bID'
+        )
+        assert car_block.series.mean() == 0.2761974319698012
 
     def test_Count(self):
         eib = mm.Count(self.blocks, self.df_buildings, "bID", "bID").series


### PR DESCRIPTION
`AreaRatio` now expects 1:1 match between covering and covered objects. This PR allows calculation worth multiple objects covering one (sharing object ID). 

Example could be Floor Area Ratio for block.