### PR TITLE
BUG: network_false_nodes for multiindex

### DIFF
--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -528,7 +528,7 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3):
         raise TypeError(
             "'gdf' should be GeoDataFrame or GeoSeries, got {}".format(type(gdf))
         )
-    streets = gdf.explode()
+    streets = gdf.reset_index(drop=True).explode()
     if isinstance(streets, gpd.GeoDataFrame):
         series = False
         streets = streets.reset_index(drop=True).geometry

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,6 +98,10 @@ class TestUtils:
         assert isinstance(fixed_series, gpd.GeoSeries)
         with pytest.raises(TypeError):
             mm.network_false_nodes(list())
+        multiindex = self.false_network.explode()
+        fixed_multiindex = mm.network_false_nodes(multiindex)
+        assert len(fixed_multiindex) == 55
+        assert isinstance(fixed, gpd.GeoDataFrame)
 
     def test_snap_street_network_edge(self):
         snapped = mm.snap_street_network_edge(


### PR DESCRIPTION
```py
net = net.explode()
mm.network_false_nodes(net)
```
This fails as `net` has MultiIndex. Fixed.