### PR TITLE
ENH: vectorize SharedWallsRatio bit, note

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,16 @@
+To cite `momepy` please use following [software paper](https://doi.org/10.21105/joss.01807) published in the JOSS.
+
+Fleischmann, M. (2019) ‘momepy: Urban Morphology Measuring Toolkit’, Journal of Open Source Software, 4(43), p. 1807. doi: 10.21105/joss.01807.
+
+BibTeX:
+
+    @article{fleischmann_2019,
+        author={Fleischmann, Martin},
+        title={momepy: Urban Morphology Measuring Toolkit},
+        journal={Journal of Open Source Software},
+        year={2019},
+        volume={4},
+        number={43},
+        pages={1807},
+        DOI={10.21105/joss.01807}
+    }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 Martin Fleischmann, University of Strathclyde
+Copyright (c) 2018-2020 Martin Fleischmann, University of Strathclyde
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -126,6 +126,9 @@ class SharedWallsRatio:
     .. math::
         \\textit{length of shared walls} \\over perimeter
 
+    Note that data needs to be topologically correct. Overlapping polygons will lead to
+    incorrect results.
+
     Parameters
     ----------
     gdf : GeoDataFrame
@@ -195,9 +198,7 @@ class SharedWallsRatio:
             if not neighbors:
                 results_list.append(0)
             else:
-                for i in neighbors:
-                    subset = gdf.iloc[i]["geometry"]
-                    length = length + row.geometry.intersection(subset).length
+                length = gdf.iloc[neighbors].intersection(row.geometry).length.sum()
                 results_list.append(length / row[perimeters])
 
         self.series = pd.Series(results_list, index=gdf.index)


### PR DESCRIPTION
SharedWallsRatio might in some cases return values higher than 1, which is clear nonsense. It is caused by imprecise geometry, when intersection of two polygons results in a polygon, not line string as expected.