### PR TITLE
REF: use vectorised operations

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -827,6 +827,7 @@ class CoveredArea:
         self.id = gdf[unique_id]
 
         data = gdf.set_index(unique_id)
+        area = data.geometry.area
 
         results_list = []
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
@@ -837,7 +838,7 @@ class CoveredArea:
                 else:
                     neighbours = [index]
 
-                areas = data.loc[neighbours].geometry.area
+                areas = area.loc[neighbours]
                 results_list.append(sum(areas))
             else:
                 results_list.append(np.nan)

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -69,6 +69,7 @@ class Orientation:
 
         # iterating over rows one by one
         for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
+            # TODO: vectorize once minimum_rotated_rectangle is in geopandas from pygeos
             bbox = list(row["geometry"].minimum_rotated_rectangle.exterior.coords)
             centroid_ab = LineString([bbox[0], bbox[1]]).centroid
             centroid_cd = LineString([bbox[2], bbox[3]]).centroid
@@ -558,7 +559,7 @@ class NeighborDistance:
                 building_neighbours = data.loc[neighbours]
                 if len(building_neighbours) > 0:
                     results_list.append(
-                        np.mean(building_neighbours.geometry.distance(row["geometry"]))
+                        building_neighbours.geometry.distance(row["geometry"]).mean()
                     )
                 else:
                     results_list.append(np.nan)

--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -105,7 +105,7 @@ class Theil:
     """
     Calculates the Theil measure of inequality of values within neighbours defined in `spatial_weights`.
 
-    Uses `inequality.theil.Theil` under the hood. Requires 'inequality' or 'pysal' package.
+    Uses `inequality.theil.Theil` under the hood. Requires 'inequality' package.
 
     .. math::
 
@@ -150,10 +150,7 @@ class Theil:
         try:
             from inequality.theil import Theil
         except ImportError:
-            try:
-                from pysal.explore.inequality.theil import Theil
-            except ImportError:
-                raise ImportError("The 'inequality' or 'pysal' package is required.")
+            raise ImportError("The 'inequality' package is required.")
 
         self.gdf = gdf
         self.sw = spatial_weights
@@ -169,6 +166,9 @@ class Theil:
 
         data = data.set_index(unique_id)
 
+        if rng:
+            from momepy import limit_range
+
         results_list = []
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
             if index in spatial_weights.neighbors.keys():
@@ -181,8 +181,6 @@ class Theil:
                 values_list = data.loc[neighbours][values]
 
                 if rng:
-                    from momepy import limit_range
-
                     values_list = limit_range(values_list, rng=rng)
                 results_list.append(Theil(values_list).T)
             else:
@@ -195,8 +193,7 @@ class Simpson:
     """
     Calculates the Simpson\'s diversity index of values within neighbours defined in `spatial_weights`.
 
-    Uses `mapclassify.classifiers` under the hood for binning. Requires `mapclassify>=.2.1.0` dependency
-    or `pysal`.
+    Uses `mapclassify.classifiers` under the hood for binning. Requires `mapclassify>=.2.1.0` dependency.
 
     .. math::
 
@@ -267,10 +264,7 @@ class Simpson:
         try:
             import mapclassify.classifiers as classifiers
         except ImportError:
-            try:
-                import pysal.viz.mapclassify.classifiers as classifiers
-            except ImportError:
-                raise ImportError("The 'mapclassify' or 'pysal' package is required")
+            raise ImportError("The 'mapclassify' package is required")
 
         schemes = {}
         for classifier in classifiers.CLASSIFIERS:
@@ -339,7 +333,7 @@ class Gini:
     """
     Calculates the Gini index of values within neighbours defined in `spatial_weights`.
 
-    Uses `inequality.gini.Gini` under the hood. Requires 'inequality' or 'pysal' package.
+    Uses `inequality.gini.Gini` under the hood. Requires 'inequality' package.
 
     Parameters
     ----------
@@ -381,10 +375,7 @@ class Gini:
         try:
             from inequality.gini import Gini
         except ImportError:
-            try:
-                from pysal.explore.inequality.gini import Gini
-            except ImportError:
-                raise ImportError("The 'inequality' or 'pysal' package is required.")
+            raise ImportError("The 'inequality' package is required.")
 
         self.gdf = gdf
         self.sw = spatial_weights
@@ -406,6 +397,9 @@ class Gini:
 
         data = data.set_index(unique_id)
 
+        if rng:
+            from momepy import limit_range
+
         results_list = []
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
             if index in spatial_weights.neighbors.keys():
@@ -416,8 +410,6 @@ class Gini:
                     values_list = data.loc[neighbours][values].values
 
                     if rng:
-                        from momepy import limit_range
-
                         values_list = np.array(limit_range(values_list, rng=rng))
                     results_list.append(Gini(values_list).g)
                 else:

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -431,6 +431,8 @@ class Reached:
 
     """
 
+    # TODO: allow all modes
+
     def __init__(
         self,
         left,
@@ -585,6 +587,8 @@ class NodeDensity:
         # define empty list for results
         results_list = []
 
+        lengths = right.geometry.length
+
         # iterating over rows one by one
         for index, row in tqdm(left.iterrows(), total=left.shape[0]):
 
@@ -596,10 +600,10 @@ class NodeDensity:
             else:
                 number_nodes = len(neighbours)
 
-            edg = right.loc[right["node_start"].isin(neighbours)].loc[
-                right["node_end"].isin(neighbours)
-            ]
-            length = sum(edg.geometry.length)
+            length = lengths.loc[
+                right["node_start"].isin(neighbours)
+                & right["node_end"].isin(neighbours)
+            ].sum()
 
             if length > 0:
                 results_list.append(number_nodes / length)

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -348,6 +348,9 @@ class BlocksCount:
         self.block_id = data[block_id]
         data = data.set_index(unique_id)
 
+        if weighted is True:
+            areas = data.geometry.area
+
         for index, row in tqdm(data.iterrows(), total=data.shape[0]):
             if index in spatial_weights.neighbors.keys():
                 neighbours = spatial_weights.neighbors[index].copy()
@@ -358,7 +361,7 @@ class BlocksCount:
                 if weighted is True:
                     results_list.append(
                         vicinity[block_id].unique().shape[0]
-                        / sum(vicinity.geometry.area)
+                        / sum(areas.loc[neighbours])
                     )
                 elif weighted is False:
                     results_list.append(vicinity[block_id].unique().shape[0])

--- a/momepy/shape.py
+++ b/momepy/shape.py
@@ -454,10 +454,9 @@ class CircularCompactness:
             gdf["mm_a"] = areas
             areas = "mm_a"
         self.areas = gdf[areas]
+        gdf["hull"] = gdf.convex_hull.exterior
         self.series = gdf.apply(
-            lambda row: (row[areas])
-            / (_circle_area(list(row["geometry"].convex_hull.exterior.coords))),
-            axis=1,
+            lambda row: (row[areas]) / (_circle_area(list(row.hull.coords))), axis=1
         )
 
 

--- a/momepy/shape.py
+++ b/momepy/shape.py
@@ -679,6 +679,7 @@ class Rectangularity:
     """
 
     def __init__(self, gdf, areas=None):
+        # TODO: vectorize minimum_rotated_rectangle after pygeos implementation
         self.gdf = gdf
         gdf = gdf.copy()
         if areas is None:
@@ -999,6 +1000,7 @@ class EquivalentRectangularIndex:
         self.areas = gdf[areas]
         # fill new column with the value of area, iterating over rows one by one
         for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
+            # TODO: vectorize minimum_rotated_rectangle after pygeos implementation
             bbox = row["geometry"].minimum_rotated_rectangle
             results_list.append(
                 math.sqrt(row[areas] / bbox.area) * (bbox.length / row[perimeters])
@@ -1049,6 +1051,7 @@ class Elongation:
 
         # fill new column with the value of area, iterating over rows one by one
         for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
+            # TODO: vectorize minimum_rotated_rectangle after pygeos implementation
             bbox = row["geometry"].minimum_rotated_rectangle
             a = bbox.area
             p = bbox.length
@@ -1222,12 +1225,13 @@ class Linearity:
         # define empty list for results
         results_list = []
 
+        lenghts = gdf.geometry.length
         # fill new column with the value of area, iterating over rows one by one
         for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
             euclidean = Point(row["geometry"].coords[0]).distance(
                 Point(row["geometry"].coords[-1])
             )
-            results_list.append(euclidean / row["geometry"].length)
+            results_list.append(euclidean / lenghts.loc[index])
 
         self.series = pd.Series(results_list, index=gdf.index)
 


### PR DESCRIPTION
Minor refactor to use vectorised operations where possible. + pysal cleanup as double import is not needed with the latest pysal structure.