### PR TITLE
ENH: SegmentsLength allow sum and mean at the same run

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -915,11 +915,11 @@ class PerimeterWall:
 
 class SegmentsLength:
     """
-    Calculate the cummulative or mean length of segments.
+    Calculate the cummulative and/or mean length of segments.
 
     Length of segments within set topological distance from each of them.
-    Reached topological distance should be captured by spatial_weights. If mean=False
-    it will return total length, if mean=True it will return mean value.
+    Reached topological distance should be captured by spatial_weights. If mean=False it
+    will compute sum of length, if mean=True it will compute sum and mean.
 
     Parameters
     ----------
@@ -929,29 +929,31 @@ class SegmentsLength:
         spatial weights matrix - If None, Queen contiguity matrix will be calculated
         based on streets (note: spatial_weights shoud be based on index, not unique ID).
     mean : boolean, optional
-        If mean=False it will return total length, if mean=True it will return mean value
+        If mean=False it will compute sum of length, if mean=True it will compute
+        sum and mean
 
     Attributes
     ----------
     series : Series
-        Series containing resulting values
+        Series containing resulting total lengths
+    mean : Series
+        Series containing resulting total lengths
+    sum : Series
+        Series containing resulting total lengths
     gdf : GeoDataFrame
         original GeoDataFrame
     sw : libpysal.weights
         spatial weights matrix
-    mean : boolean
-        used mean boolean value
 
     Examples
     --------
-    >>> streets_df['length_neighbours'] = mm.SegmentsLength(streets_df, mean=True).series
+    >>> streets_df['length_neighbours'] = mm.SegmentsLength(streets_df, mean=True).mean
     Calculating spatial weights...
     Spatial weights ready...
     """
 
     def __init__(self, gdf, spatial_weights=None, mean=False):
         self.gdf = gdf
-        self.mean = mean
 
         if spatial_weights is None:
             print("Calculating spatial weights...")
@@ -961,7 +963,10 @@ class SegmentsLength:
             print("Spatial weights ready...")
         self.sw = spatial_weights
 
-        results_list = []
+        lenghts = gdf.geometry.length
+
+        sums = []
+        means = []
         for index, row in tqdm(gdf.iterrows(), total=gdf.shape[0]):
             neighbours = spatial_weights.neighbors[index].copy()
             if neighbours:
@@ -969,10 +974,11 @@ class SegmentsLength:
             else:
                 neighbours = [index]
 
-            dims = gdf.iloc[neighbours].geometry.length
+            dims = lenghts.iloc[neighbours]
             if mean:
-                results_list.append(np.mean(dims))
-            else:
-                results_list.append(sum(dims))
+                means.append(np.mean(dims))
+            sums.append(sum(dims))
 
-        self.series = pd.Series(results_list, index=gdf.index)
+        self.series = self.sum = pd.Series(sums, index=gdf.index)
+        if mean:
+            self.mean = pd.Series(means, index=gdf.index)

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -229,7 +229,7 @@ class TestDimensions:
         assert wall[0] == 137.2106961418436
 
     def test_SegmentsLength(self):
-        absol = mm.SegmentsLength(self.df_streets).series
-        mean = mm.SegmentsLength(self.df_streets, mean=True).series
+        absol = mm.SegmentsLength(self.df_streets).sum
+        mean = mm.SegmentsLength(self.df_streets, mean=True).mean
         assert max(absol) == 1907.502238338006
         assert max(mean) == 249.5698434867373


### PR DESCRIPTION
This is a breaking change. If `mean=True`, resulting series is in `self.mean`, not `self.series` anymore. Sum is computed always.