### PR TITLE
ENH: multiple modes in AverageCharacter at the same run

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -371,7 +371,7 @@ class AverageCharacter:
         Series containing used unique ID
     rng : tuple
         range
-    mode : str
+    modes : str
         mode
 
     References
@@ -394,12 +394,10 @@ class AverageCharacter:
         self.sw = spatial_weights
         self.id = gdf[unique_id]
         self.rng = rng
-        self.mode = mode
+        self.modes = mode
 
         if rng:
             from momepy import limit_range
-
-        # ADD MODE DEPRECATION WARNING
 
         data = gdf.copy()
         if values is not None:

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -160,6 +160,14 @@ class TestDimensions:
                 unique_id="uID",
                 mode="nonexistent",
             )
+        with pytest.raises(ValueError):
+            self.df_tessellation["mesh_ar"] = mm.AverageCharacter(
+                self.df_tessellation,
+                values="area",
+                spatial_weights=spatial_weights,
+                unique_id="uID",
+                mode=["nonexistent", "mean"],
+            )
         assert self.df_tessellation["mesh_ar"][0] == approx(249.503, rel=1e-3)
         assert self.df_tessellation["mesh_array"][0] == approx(2623.996, rel=1e-3)
         assert self.df_tessellation["mesh_id"][38] == approx(2250.224, rel=1e-3)

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -139,7 +139,7 @@ class TestDimensions:
             rng=(25, 75),
             unique_id="uID",
         ).series
-        all = mm.AverageCharacter(
+        all_m = mm.AverageCharacter(
             self.df_tessellation,
             spatial_weights=spatial_weights,
             values="area",
@@ -164,10 +164,10 @@ class TestDimensions:
         assert self.df_tessellation["mesh_array"][0] == approx(2623.996, rel=1e-3)
         assert self.df_tessellation["mesh_id"][38] == approx(2250.224, rel=1e-3)
         assert self.df_tessellation["mesh_iq"][38] == approx(2118.609, rel=1e-3)
-        assert all.mean[0] == approx(2922.957, rel=1e-3)
-        assert all.median[0] == approx(2623.996, rel=1e-3)
-        assert all.mode[0] == approx(249.503, rel=1e-3)
-        assert all.series[0] == approx(2922.957, rel=1e-3)
+        assert all_m.mean[0] == approx(2922.957, rel=1e-3)
+        assert all_m.median[0] == approx(2623.996, rel=1e-3)
+        assert all_m.mode[0] == approx(249.503, rel=1e-3)
+        assert all_m.series[0] == approx(2922.957, rel=1e-3)
         assert two.mean[0] == approx(2922.957, rel=1e-3)
         assert two.median[0] == approx(2623.996, rel=1e-3)
         sw_drop = sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -117,21 +117,21 @@ class TestDimensions:
             spatial_weights=spatial_weights,
             unique_id="uID",
             mode="mode",
-        ).series
+        ).mode
         self.df_tessellation["mesh_array"] = mm.AverageCharacter(
             self.df_tessellation,
             values=area,
             spatial_weights=spatial_weights,
             unique_id="uID",
             mode="median",
-        ).series
+        ).median
         self.df_tessellation["mesh_id"] = mm.AverageCharacter(
             self.df_tessellation,
             spatial_weights=spatial_weights,
             values="area",
             rng=(10, 90),
             unique_id="uID",
-        ).series
+        ).mean
         self.df_tessellation["mesh_iq"] = mm.AverageCharacter(
             self.df_tessellation,
             spatial_weights=spatial_weights,
@@ -139,6 +139,19 @@ class TestDimensions:
             rng=(25, 75),
             unique_id="uID",
         ).series
+        all = mm.AverageCharacter(
+            self.df_tessellation,
+            spatial_weights=spatial_weights,
+            values="area",
+            unique_id="uID",
+        )
+        two = mm.AverageCharacter(
+            self.df_tessellation,
+            spatial_weights=spatial_weights,
+            values="area",
+            unique_id="uID",
+            mode=["mean", "median"],
+        )
         with pytest.raises(ValueError):
             self.df_tessellation["mesh_ar"] = mm.AverageCharacter(
                 self.df_tessellation,
@@ -151,6 +164,12 @@ class TestDimensions:
         assert self.df_tessellation["mesh_array"][0] == approx(2623.996, rel=1e-3)
         assert self.df_tessellation["mesh_id"][38] == approx(2250.224, rel=1e-3)
         assert self.df_tessellation["mesh_iq"][38] == approx(2118.609, rel=1e-3)
+        assert all.mean[0] == approx(2922.957, rel=1e-3)
+        assert all.median[0] == approx(2623.996, rel=1e-3)
+        assert all.mode[0] == approx(249.503, rel=1e-3)
+        assert all.series[0] == approx(2922.957, rel=1e-3)
+        assert two.mean[0] == approx(2922.957, rel=1e-3)
+        assert two.median[0] == approx(2623.996, rel=1e-3)
         sw_drop = sw_high(k=3, gdf=self.df_tessellation[2:], ids="uID")
         assert (
             mm.AverageCharacter(


### PR DESCRIPTION
Allowing calculation of multiple averages (mean, median, mode) during the single run through gdf. It is a breaking change, as each of the will come with its own attribute `.mean`, `.median`, `.mode`, not in `.series`, which is just a copy of mean to keep default the same.