### PR TITLE
ENH: osmnx compatibility

### DIFF
--- a/ci/travis/37-pysal.yaml
+++ b/ci/travis/37-pysal.yaml
@@ -12,5 +12,6 @@ dependencies:
   - codecov
   - pysal
   - pip
+  - osmnx
   - pip:
     - black

--- a/ci/travis/dev.yaml
+++ b/ci/travis/dev.yaml
@@ -12,6 +12,7 @@ dependencies:
   - codecov
   - mapclassify
   - pip
+  - osmnx
   - pip:
     - black
     - nose

--- a/ci/travis/latest-mc.yaml
+++ b/ci/travis/latest-mc.yaml
@@ -12,6 +12,7 @@ dependencies:
   - codecov
   - mapclassify
   - pip
+  - osmnx
   - pip:
     - inequality
     - black

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -335,22 +335,18 @@ def nx_to_gdf(net, points=True, lines=True, spatial_weights=False, nodeID="nodeI
                 net.graph["approach"]
             )
         )
-    else:
-        import warnings
 
-        warnings.warn("Approach is not set. Defaulting to 'primal'.")
+    import warnings
 
-        nid = 1
-        for n in net:
-            net.nodes[n][nodeID] = nid
-            nid += 1
-        return _primal_to_gdf(
-            net,
-            points=points,
-            lines=lines,
-            spatial_weights=spatial_weights,
-            nodeID=nodeID,
-        )
+    warnings.warn("Approach is not set. Defaulting to 'primal'.")
+
+    nid = 1
+    for n in net:
+        net.nodes[n][nodeID] = nid
+        nid += 1
+    return _primal_to_gdf(
+        net, points=points, lines=lines, spatial_weights=spatial_weights, nodeID=nodeID
+    )
 
 
 def limit_range(vals, rng):

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -222,12 +222,13 @@ def _points_to_gdf(net, spatial_weights):
     Helper for nx_to_gdf.
     """
     node_xy, node_data = zip(*net.nodes(data=True))
-    if len(node_xy[0]) == 2:
-        geometry = [Point(i, j) for i, j in node_xy]
-    elif len(node_xy[0]) == 3:
-        geometry = [Point(i, j, k) for i, j, k in node_xy]
+    if isinstance(node_xy[0], int) and "x" in node_data[0].keys():
+        geometry = [Point(data["x"], data["y"]) for data in node_data]  # osmnx graph
+    else:
+        geometry = [Point(*p) for p in node_xy]
     gdf_nodes = gpd.GeoDataFrame(list(node_data), geometry=geometry)
-    gdf_nodes.crs = net.graph["crs"]
+    if "crs" in net.graph.keys():
+        gdf_nodes.crs = net.graph["crs"]
     return gdf_nodes
 
 
@@ -248,7 +249,8 @@ def _lines_to_gdf(net, lines, points, nodeID):
     if points is True:
         gdf_edges["node_start"] = node_start
         gdf_edges["node_end"] = node_end
-    gdf_edges.crs = net.graph["crs"]
+    if "crs" in net.graph.keys():
+        gdf_edges.crs = net.graph["crs"]
     return gdf_edges
 
 
@@ -313,7 +315,7 @@ def nx_to_gdf(net, points=True, lines=True, spatial_weights=False, nodeID="nodeI
 
     """
     # generate nodes and edges geodataframes from graph
-    try:
+    if "approach" in net.graph.keys():
         if net.graph["approach"] == "primal":
             nid = 1
             for n in net:
@@ -333,10 +335,21 @@ def nx_to_gdf(net, points=True, lines=True, spatial_weights=False, nodeID="nodeI
                 net.graph["approach"]
             )
         )
-    except KeyError:
-        raise KeyError(
-            "Approach is not set. Graph needs an attribute 'approach' to be set"
-            "either to 'primal' or to 'dual'.".format(net.graph["approach"])
+    else:
+        import warnings
+
+        warnings.warn("Approach is not set. Defaulting to 'primal'.")
+
+        nid = 1
+        for n in net:
+            net.nodes[n][nodeID] = nid
+            nid += 1
+        return _primal_to_gdf(
+            net,
+            points=points,
+            lines=lines,
+            spatial_weights=spatial_weights,
+            nodeID=nodeID,
         )
 
 


### PR DESCRIPTION
Updated `nx_to_gdf()` to be compatible with osmnx graph. Now it should be possible to use osmnx graphs and other without expected structure directly within momepy and then save then using `nx_to_gdf()`. However, it is not recommended as `osmnx.save_load.graph_to_gdfs()` is tailored to OSM data, unlike `nx_to_gdf()` which expects already cleaned data.