### PR TITLE
ENH: Gini-Simpson index, Inverse Simpson index

### DIFF
--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -216,6 +216,10 @@ class Simpson:
         JenksCaspallForced, JenksCaspallSampled, MaxPClassifier,
         MaximumBreaks, NaturalBreaks, Quantiles, Percentiles, StdMean,
         UserDefined
+    gini_simpson : bool (default False)
+        return Gini-Simpson index instead of Simpson index (1 - λ)
+    inverse : bool (default False)
+        return Inverse Simpson index instead of Simpson index (1 / λ)
     **classification_kwds : dict
         Keyword arguments for classification scheme
         For details see mapclassify documentation:
@@ -237,10 +241,6 @@ class Simpson:
         binning method
     bins : mapclassify.classifiers.Classifier
         generated bins
-    gini_simpson : bool (default False)
-        return Gini-Simpson index instead of Simpson index (1 - λ)
-    inverse : bool (default False)
-        return Inverse Simpson index instead of Simpson index (1 / λ)
     classification_kwds : dict
         classification_kwds
 

--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -237,6 +237,10 @@ class Simpson:
         binning method
     bins : mapclassify.classifiers.Classifier
         generated bins
+    gini_simpson : bool (default False)
+        return Gini-Simpson index instead of Simpson index (1 - λ)
+    inverse : bool (default False)
+        return Inverse Simpson index instead of Simpson index (1 / λ)
     classification_kwds : dict
         classification_kwds
 
@@ -259,6 +263,8 @@ class Simpson:
         spatial_weights,
         unique_id,
         binning="HeadTailBreaks",
+        gini_simpson=False,
+        inverse=False,
         **classification_kwds
     ):
         try:
@@ -306,7 +312,12 @@ class Simpson:
             else:
                 results_list.append(np.nan)
 
-        self.series = pd.Series(results_list, index=gdf.index)
+        if gini_simpson:
+            self.series = 1 - pd.Series(results_list, index=gdf.index)
+        elif inverse:
+            self.series = 1 / pd.Series(results_list, index=gdf.index)
+        else:
+            self.series = pd.Series(results_list, index=gdf.index)
 
     def _simpson_di(self, data):
 

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -88,6 +88,15 @@ class TestDiversity:
             .series.isna()
             .any()
         )
+        gs = mm.Simpson(
+            self.df_tessellation, "area", self.sw, "uID", gini_simpson=True
+        ).series
+        assert gs[0] == 1 - 0.385
+
+        inv = mm.Simpson(
+            self.df_tessellation, "area", self.sw, "uID", inverse=True
+        ).series
+        assert inv[0] == 1 / 0.385
 
     def test_Gini(self):
         full_sw = mm.Gini(self.df_tessellation, "area", self.sw, "uID").series


### PR DESCRIPTION
Additional options for `Simpson` diversity character. Can be returned as Gini-Simpson (1-λ) or Inverse Simpson index (1/λ). For details see [wikipedia](https://en.wikipedia.org/wiki/Diversity_index).