### PR TITLE
BUG: Density TypeError for islands

### DIFF
--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -695,7 +695,7 @@ class Density:
                 values_list = subset[values]
                 areas_list = subset[areas]
 
-                results_list.append(sum(values_list) / sum(areas_list))
+                results_list.append(np.sum(values_list) / np.sum(areas_list))
             else:
                 results_list.append(np.nan)
 

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -216,3 +216,14 @@ class TestIntensity:
             .series.isna()
             .any()
         )
+
+        # island
+        sw.neighbors[1] = []
+        dens3 = mm.Density(
+            self.df_tessellation,
+            self.df_buildings["fl_area"],
+            sw,
+            "uID",
+            self.df_tessellation.area,
+        ).series
+        assert dens3.mean() == approx(1.656420)


### PR DESCRIPTION
In case of islands in spatial weights `Density` raised TypeError.