### PR TITLE
ENH: On demand DistanceBand spatial weights (neighbors)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -127,6 +127,15 @@ diversity
    Theil
    Unique
 
+spatial weights
+---------------
+.. autosummary::
+   :toctree: generated/
+
+   DistanceBand
+   sw_high
+
+
 utilities
 ---------
 .. autosummary::
@@ -139,5 +148,4 @@ utilities
    nx_to_gdf
    preprocess
    snap_street_network_edge
-   sw_high
    unique_id

--- a/momepy/__init__.py
+++ b/momepy/__init__.py
@@ -6,6 +6,7 @@ from .diversity import *
 from .distribution import *
 from .graph import *
 from .shape import *
+from .weights import *
 import momepy.datasets
 
 __author__ = "Martin Fleischmann"

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -17,7 +17,6 @@ from .shape import CircularCompactness
 
 __all__ = [
     "unique_id",
-    "sw_high",
     "gdf_to_nx",
     "nx_to_gdf",
     "limit_range",
@@ -45,70 +44,6 @@ def unique_id(objects):
     """
     series = range(len(objects))
     return series
-
-
-def sw_high(k, gdf=None, weights=None, ids=None, contiguity="queen", silent=True):
-    """
-    Generate spatial weights based on Queen or Rook contiguity of order k.
-
-    Adjacent are all features within <= k steps. Pass either gdf or weights.
-    If both are passed, weights is used. If weights are passed, contiguity is
-    ignored and high order spatial weights based on `weights` are computed.
-
-    Parameters
-    ----------
-    k : int
-        order of contiguity
-    gdf : GeoDataFrame
-        GeoDataFrame containing objects to analyse. Index has to be consecutive range 0:x.
-        Otherwise, spatial weights will not match objects.
-    weights : libpysal.weights
-        libpysal.weights of order 1
-    contiguity : str (default 'queen')
-        type of contiguity weights. Can be 'queen' or 'rook'.
-    silent : bool (default True)
-        silence libpysal islands warnings
-
-    Returns
-    -------
-    libpysal.weights
-        libpysal.weights object
-
-    Examples
-    --------
-    >>> first_order = libpysal.weights.Queen.from_dataframe(geodataframe)
-    >>> first_order.mean_neighbors
-    5.848032564450475
-    >>> fourth_order = sw_high(k=4, gdf=geodataframe)
-    >>> fourth.mean_neighbors
-    85.73188602442333
-
-    """
-    if weights is not None:
-        first_order = weights
-    elif gdf is not None:
-        if contiguity == "queen":
-            first_order = libpysal.weights.Queen.from_dataframe(
-                gdf, ids=ids, silence_warnings=silent
-            )
-        elif contiguity == "rook":
-            first_order = libpysal.weights.Rook.from_dataframe(
-                gdf, ids=ids, silence_warnings=silent
-            )
-        else:
-            raise ValueError(
-                "{} is not supported. Use 'queen' or 'rook'.".format(contiguity)
-            )
-    else:
-        raise AttributeError("GeoDataFrame or spatial weights must be given.")
-
-    joined = first_order
-    for i in list(range(2, k + 1)):
-        i_order = libpysal.weights.higher_order(
-            first_order, k=i, silence_warnings=silent
-        )
-        joined = libpysal.weights.w_union(joined, i_order, silence_warnings=silent)
-    return joined
 
 
 def _angle(a, b, c):

--- a/momepy/weights.py
+++ b/momepy/weights.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import libpysal
+import numpy as np
+
+
+__all__ = ["DistanceBand", "sw_high"]
+
+
+class DistanceBand:
+    """
+    On demand distance-based spatial weights-like class.
+
+    Mimic the behavior of `libpysal.weights.DistanceBand` but do not compute all
+    neighbors at once but only on demand. Only `DistanceBand.neighbors[key]` is
+    implemented. Once user asks for `DistanceBand.neighbors[key]`, neigbors for
+    specified key will be computed using rtree. The algorithm is significantly
+    slower than `libpysal.weights.DistanceBand` but allows for large number of
+    neighbors which may cause memory issues in libpysal.
+
+    Use `libpysal.weights.DistanceBand` if possible. `momepy.weights.DistanceBand`
+    only when necessary. DistanceBand.neighbors[key] should yield same results as
+    DistanceBand.
+
+    Parameters
+    ----------
+    gdf : GeoDataFrame or GeoSeries
+        GeoDataFrame containing objects to be used as `gdf` in `Tessellation`
+    threshold : float
+        distance band to be used as buffer
+    centroid : bool (default True)
+        use centroid of geometry (as in libpysal.weights.DistanceBand).
+        If False, works with the geometry as it is.
+    ids : str
+        column to be used as geometry ids. If not set, integer position is used.
+
+    Attributes
+    ----------
+    neigbors[key] : list
+        list of ids of neighboring features
+
+    """
+
+    def __init__(self, gdf, threshold, centroid=True, ids=None):
+        if centroid:
+            gdf.geometry = gdf.centroid
+
+        self.neighbors = _Neighbors(gdf, threshold, ids=ids)
+
+    def fetch_items(self, key):
+        possible_matches_index = list(
+            self.sindex.intersection(self.bufferred[key].bounds)
+        )
+        possible_matches = self.geoms.iloc[possible_matches_index]
+        match = possible_matches.index[
+            possible_matches.intersects(self.bufferred[key])
+        ].to_list()
+        match.remove(key)
+        return match
+
+
+class _Neighbors(dict, DistanceBand):
+    """
+    Helper class for DistanceBand.
+    """
+
+    def __init__(self, geoms, buffer, ids):
+        self.geoms = geoms
+        self.sindex = geoms.sindex
+        self.bufferred = geoms.buffer(buffer)
+        if ids:
+            self.ids = np.array(geoms[ids])
+        else:
+            self.ids = range(len(self.geoms))
+        if ids:
+            self.ids_bool = True
+        else:
+            self.ids_bool = False
+
+    def __missing__(self, key):
+        if self.ids_bool:
+            int_id = np.where(self.ids == key)[0][0]
+            integers = self.fetch_items(int_id)
+            self[key] = item = list(self.ids[integers])
+            return item
+        else:
+            integers = self.fetch_items(key)
+            self[key] = item = integers
+            return item
+
+    def keys(self):
+        return self.ids
+
+
+def sw_high(k, gdf=None, weights=None, ids=None, contiguity="queen", silent=True):
+    """
+    Generate spatial weights based on Queen or Rook contiguity of order k.
+
+    Adjacent are all features within <= k steps. Pass either gdf or weights.
+    If both are passed, weights is used. If weights are passed, contiguity is
+    ignored and high order spatial weights based on `weights` are computed.
+
+    Parameters
+    ----------
+    k : int
+        order of contiguity
+    gdf : GeoDataFrame
+        GeoDataFrame containing objects to analyse. Index has to be consecutive range 0:x.
+        Otherwise, spatial weights will not match objects.
+    weights : libpysal.weights
+        libpysal.weights of order 1
+    contiguity : str (default 'queen')
+        type of contiguity weights. Can be 'queen' or 'rook'.
+    silent : bool (default True)
+        silence libpysal islands warnings
+
+    Returns
+    -------
+    libpysal.weights
+        libpysal.weights object
+
+    Examples
+    --------
+    >>> first_order = libpysal.weights.Queen.from_dataframe(geodataframe)
+    >>> first_order.mean_neighbors
+    5.848032564450475
+    >>> fourth_order = sw_high(k=4, gdf=geodataframe)
+    >>> fourth.mean_neighbors
+    85.73188602442333
+
+    """
+    if weights is not None:
+        first_order = weights
+    elif gdf is not None:
+        if contiguity == "queen":
+            first_order = libpysal.weights.Queen.from_dataframe(
+                gdf, ids=ids, silence_warnings=silent
+            )
+        elif contiguity == "rook":
+            first_order = libpysal.weights.Rook.from_dataframe(
+                gdf, ids=ids, silence_warnings=silent
+            )
+        else:
+            raise ValueError(
+                "{} is not supported. Use 'queen' or 'rook'.".format(contiguity)
+            )
+    else:
+        raise AttributeError("GeoDataFrame or spatial weights must be given.")
+
+    joined = first_order
+    for i in list(range(2, k + 1)):
+        i_order = libpysal.weights.higher_order(
+            first_order, k=i, silence_warnings=silent
+        )
+        joined = libpysal.weights.w_union(joined, i_order, silence_warnings=silent)
+    return joined

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -37,8 +37,10 @@ class TestWeights:
         db_ids = mm.DistanceBand(self.df_buildings, 100, ids="uID")
 
         for k in range(len(self.df_buildings)):
+            assert k in db.neighbors.keys()
             assert sorted(lp.neighbors[k]) == sorted(db.neighbors[k])
         for k in self.df_buildings.uID:
+            assert k in db_ids.neighbors.keys()
             assert sorted(lp_ids.neighbors[k]) == sorted(db_ids.neighbors[k])
 
         db_cent_false = mm.DistanceBand(self.df_buildings, 100, centroid=False)

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,0 +1,45 @@
+import geopandas as gpd
+import libpysal
+import momepy as mm
+import pytest
+
+
+class TestWeights:
+    def setup_method(self):
+
+        test_file_path = mm.datasets.get_path("bubenec")
+        self.df_buildings = gpd.read_file(test_file_path, layer="buildings")
+        self.df_tessellation = gpd.read_file(test_file_path, layer="tessellation")
+        self.df_tessellation["area"] = mm.Area(self.df_tessellation).series
+
+    def test_sw_high(self):
+        first_order = libpysal.weights.Queen.from_dataframe(self.df_tessellation)
+        from_sw = mm.sw_high(2, gdf=None, weights=first_order)
+        from_df = mm.sw_high(2, gdf=self.df_tessellation)
+        rook = mm.sw_high(2, gdf=self.df_tessellation, contiguity="rook")
+        check = [133, 134, 111, 112, 113, 114, 115, 121, 125]
+        assert from_sw.neighbors[0] == check
+        assert from_df.neighbors[0] == check
+        assert rook.neighbors[0] == check
+
+        with pytest.raises(AttributeError):
+            mm.sw_high(2, gdf=None, weights=None)
+
+        with pytest.raises(ValueError):
+            mm.sw_high(2, gdf=self.df_tessellation, contiguity="nonexistent")
+
+    def test_DistanceBand(self):
+        lp = libpysal.weights.DistanceBand.from_dataframe(self.df_buildings, 100)
+        lp_ids = libpysal.weights.DistanceBand.from_dataframe(
+            self.df_buildings, 100, ids="uID"
+        )
+        db = mm.DistanceBand(self.df_buildings, 100)
+        db_ids = mm.DistanceBand(self.df_buildings, 100, ids="uID")
+
+        for k in range(len(self.df_buildings)):
+            assert sorted(lp.neighbors[k]) == sorted(db.neighbors[k])
+        for k in self.df_buildings.uID:
+            assert sorted(lp_ids.neighbors[k]) == sorted(db_ids.neighbors[k])
+
+        db_cent_false = mm.DistanceBand(self.df_buildings, 100, centroid=False)
+        assert db_cent_false.neighbors[0] == [125, 133, 114, 134, 113, 121]


### PR DESCRIPTION
In some cases, `libpysal.weights.DistanceBand` may become too big for memory, e.g. for large thresholds. `momepy.DistanceBand` mimics its behaviour in terms of `.neighbors[key]` pattern used within momepy to compute neighbours only on demand to avoid memory issues. It is significantly slower method, but allows large thresholds which would otherwise not fit in memory. 

`momepy.DistanceBand` can be used within most momepy classes directly as spatial_weights instead of `libpysal.weights`.