### PR TITLE
API: Convexity typo, typos

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,7 +48,7 @@ shape
   CentroidCorners
   CircularCompactness
   CompactnessWeightedAxis
-  Convexeity
+  Convexity
   Corners
   CourtyardIndex
   Elongation

--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # dimension.py
-# definitons of dimension characters
+# definitions of dimension characters
 
 import math
 
@@ -481,7 +481,7 @@ class StreetProfile:
     distance : int (default 10)
         distance between perpendicular ticks
     tick_length : int (default 50)
-        lenght of ticks
+        length of ticks
 
     Attributes
     ----------
@@ -504,7 +504,7 @@ class StreetProfile:
     distance : int
         distance between perpendicular ticks
     tick_length : int
-        lenght of ticks
+        length of ticks
     heights : GeoDataFrame
         Series containing used height values
 
@@ -945,7 +945,7 @@ class SegmentsLength:
         GeoDataFrame containing streets (edges) to analyse
     spatial_weights : libpysal.weights, optional
         spatial weights matrix - If None, Queen contiguity matrix will be calculated
-        based on streets (note: spatial_weights shoud be based on index, not unique ID).
+        based on streets (note: spatial_weights should be based on index, not unique ID).
     mean : boolean, optional
         If mean=False it will compute sum of length, if mean=True it will compute
         sum and mean

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # distribution.py
-# definitons of spatial distribution characters
+# definitions of spatial distribution characters
 
 import math
 import statistics

--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # diversity.py
-# definitons of diversity characters
+# definitions of diversity characters
 
 import numpy as np
 import pandas as pd

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -61,12 +61,12 @@ class Tessellation:
     particular patterns causign issues.\n
     1. Features will collapse into empty polygon - these do not have tessellation
     cell in the end.\n
-    2. Features will split into MultiPolygon - at some cases, featuers with narrow links
+    2. Features will split into MultiPolygon - at some cases, features with narrow links
     between parts split into two during 'shrinking'. In most cases that is not an issue
     and resulting tessellation is correct anyway, but sometimes this result in a cell
     being MultiPolygon, which is not correct.\n
     3. Overlapping features - features which overlap even after 'shrinking' cause invalid
-    tessellation geoemtry.\n
+    tessellation geometry.\n
     All three types can be tested prior :class:`momepy.Tessellation` using :class:`momepy.CheckTessellationInput`.
 
     Parameters
@@ -80,7 +80,7 @@ class Tessellation:
     shrink : float (default 0.4)
         distance for negative buffer to generate space between adjacent polygons (if geometry type of gdf is (Multi)Polygon).
     segment : float (default 0.5)
-        maximum distance between points after discretisation
+        maximum distance between points after discretization
 
     Attributes
     ----------

--- a/momepy/graph.py
+++ b/momepy/graph.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # connectivity.py
-# definitons of connectivity characters
+# definitions of connectivity characters
 import math
 
 import networkx as nx
@@ -41,7 +41,7 @@ def node_degree(graph, name="degree"):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     name : str (default 'degree')
         calculated attribute name
 
@@ -91,7 +91,7 @@ def meshedness(graph, radius=5, name="meshedness", distance=None):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -133,7 +133,7 @@ def mean_node_dist(graph, name="meanlen", length="mm_len"):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     name : str, optional
         calculated attribute name
     length : str, optional
@@ -197,10 +197,10 @@ def cds_length(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius : int
         number of topological steps defining the extent of subgraph
-    mode : str (defualt 'sum')
+    mode : str (default 'sum')
         if ``'sum'``, calculate total length, if ``'mean'`` calculate mean length
     name : str, optional
         calculated attribute name
@@ -238,7 +238,7 @@ def cds_length(
         )  # define subgraph of steps=radius
         netx.nodes[n][name] = _cds_length(
             sub, mode=mode, length=length
-        )  # save value calulated for subgraph to node
+        )  # save value calculated for subgraph to node
 
     return netx
 
@@ -263,7 +263,7 @@ def mean_node_degree(graph, radius=5, name="mean_nd", degree="degree", distance=
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         radius defining the extent of subgraph
     name : str, optional
@@ -320,7 +320,7 @@ def proportion(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     three : str, optional
@@ -393,7 +393,7 @@ def cyclomatic(graph, radius=5, name="cyclomatic", distance=None):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -453,7 +453,7 @@ def edge_node_ratio(graph, radius=5, name="edge_node_ratio", distance=None):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -515,7 +515,7 @@ def gamma(graph, radius=5, name="gamma", distance=None):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -557,7 +557,7 @@ def clustering(graph, name="cluster"):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     name : str, optional
         calculated attribute name
 
@@ -692,7 +692,7 @@ def local_closeness_centrality(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -749,7 +749,7 @@ def closeness_centrality(graph, name="closeness", weight="mm_len", **kwargs):
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     name : str, optional
         calculated attribute name
     weight : str (default 'mm_len')
@@ -812,7 +812,7 @@ def betweenness_centrality(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     name : str, optional
         calculated attribute name
     mode : str, default 'nodes'
@@ -901,7 +901,7 @@ def local_betweenness_centrality(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -1003,7 +1003,7 @@ def straightness_centrality(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     weight : str (default 'mm_len')
         attribute holding length of edge
     normalized : bool
@@ -1049,7 +1049,7 @@ def local_straightness_centrality(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         number of topological steps defining the extent of subgraph
     name : str, optional
@@ -1114,7 +1114,7 @@ def subgraph(
     ----------
     graph : networkx.Graph
         Graph representing street network.
-        Ideally genereated from GeoDataFrame using :func:`momepy.gdf_to_nx`
+        Ideally generated from GeoDataFrame using :func:`momepy.gdf_to_nx`
     radius: int
         radius defining the extent of subgraph
     distance : str, optional

--- a/momepy/intensity.py
+++ b/momepy/intensity.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # intensity.py
-# definitons of intensity characters
+# definitions of intensity characters
 
 import collections
 

--- a/momepy/shape.py
+++ b/momepy/shape.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # shape.py
-# definitons of shape characters
+# definitions of shape characters
 
 import math
 import random
@@ -18,7 +18,7 @@ __all__ = [
     "VolumeFacadeRatio",
     "CircularCompactness",
     "SquareCompactness",
-    "Convexeity",
+    "Convexity",
     "CourtyardIndex",
     "Rectangularity",
     "ShapeIndex",
@@ -164,7 +164,7 @@ class VolumeFacadeRatio:
     Calculates volume/facade ratio of each object in given GeoDataFrame.
 
     .. math::
-        volume \\over perimeter * heigth
+        volume \\over perimeter * height
 
     Adapted from :cite:`schirmer2015`.
 
@@ -508,9 +508,9 @@ class SquareCompactness:
         self.series = ((np.sqrt(gdf[areas]) * 4) / gdf[perimeters]) ** 2
 
 
-class Convexeity:
+class Convexity:
     """
-    Calculates convexeity index of each object in given GeoDataFrame.
+    Calculates Convexity index of each object in given GeoDataFrame.
 
     .. math::
         area \\over \\textit{convex hull area}
@@ -536,8 +536,8 @@ class Convexeity:
 
     Examples
     --------
-    >>> buildings_df['convexeity'] = momepy.Convexeity(buildings_df).series
-    >>> buildings_df.convexeity[0]
+    >>> buildings_df['convexity'] = momepy.Convexity(buildings_df).series
+    >>> buildings_df['convexity'][0]
     0.8151964258521672
     """
 

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -460,9 +460,9 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3):
     Parameters
     ----------
     gdf : GeoDataFrame, GeoSeries
-        GeoDataFrame  or GeoSeries containg edge representation of street network.
+        GeoDataFrame  or GeoSeries containing edge representation of street network.
     tolerance : float
-        nodes wihtin tolearance are seen as identical (floating point precision fix)
+        nodes within a tolerance are seen as identical (floating point precision fix)
     precision : int
         rounding parameter in estimating uniqueness of two points based on their
         coordinates
@@ -559,7 +559,7 @@ def snap_street_network_edge(
     """
     Fix street network before performing :class:`momepy.Blocks`.
 
-    Extends unjoined ends of street segments to join with other segmets or
+    Extends unjoined ends of street segments to join with other segments or
     tessellation boundary.
 
     Parameters
@@ -884,7 +884,7 @@ class CheckTessellationInput:
     and resulting tessellation is correct anyway, but sometimes this result in a cell
     being MultiPolygon, which is not correct.\n
     3. Overlapping features - features which overlap even after 'shrinking' cause
-    invalid tessellation geoemtry.\n
+    invalid tessellation geometry.\n
 
     :class:`CheckTessellationInput` will check for all of these. Overlapping features
     have to be fixed prior Tessellation. Features which will split will cause issues

--- a/momepy/weights.py
+++ b/momepy/weights.py
@@ -14,7 +14,7 @@ class DistanceBand:
 
     Mimic the behavior of ``libpysal.weights.DistanceBand`` but do not compute all
     neighbors at once but only on demand. Only ``DistanceBand.neighbors[key]`` is
-    implemented. Once user asks for ``DistanceBand.neighbors[key]``, neigbors for
+    implemented. Once user asks for ``DistanceBand.neighbors[key]``, neighbors for
     specified key will be computed using rtree. The algorithm is significantly
     slower than ``libpysal.weights.DistanceBand`` but allows for large number of
     neighbors which may cause memory issues in libpysal.
@@ -37,7 +37,7 @@ class DistanceBand:
 
     Attributes
     ----------
-    neigbors[key] : list
+    neighbors[key] : list
         list of ids of neighboring features
 
     """

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -113,15 +113,15 @@ class TestShape:
 
         assert self.df_buildings["sqcom2"][0] == check
 
-    def test_Convexeity(self):
-        self.df_buildings["conv"] = mm.Convexeity(self.df_buildings).series
+    def test_Convexity(self):
+        self.df_buildings["conv"] = mm.Convexity(self.df_buildings).series
         check = (
             self.df_buildings.geometry.area[0]
             / self.df_buildings.geometry.convex_hull.area[0]
         )
         assert self.df_buildings["conv"][0] == check
 
-        self.df_buildings["conv2"] = mm.Convexeity(
+        self.df_buildings["conv2"] = mm.Convexity(
             self.df_buildings, areas=self.df_buildings.geometry.area
         ).series
 


### PR DESCRIPTION
Fixed typos across docstrings.

Includes API change `Convexeity` -> `Convexity`. Since we're still in early dev phases, it is a hard breaking change without deprecation.