### PR TITLE
ENV: use only conda-forge

### DIFF
--- a/ci/travis/37-pysal.yaml
+++ b/ci/travis/37-pysal.yaml
@@ -11,7 +11,5 @@ dependencies:
   - pytest-cov
   - codecov
   - pysal
-  - pip
   - osmnx
-  - pip:
-    - black
+  - black

--- a/ci/travis/dev.yaml
+++ b/ci/travis/dev.yaml
@@ -13,7 +13,6 @@ dependencies:
   - mapclassify
   - pip
   - osmnx
-  - pip:
-    - black
-    - nose
-    - inequality
+  - black
+  - nose
+  - inequality

--- a/ci/travis/latest-mc.yaml
+++ b/ci/travis/latest-mc.yaml
@@ -16,7 +16,5 @@ dependencies:
   - osmnx
   - matplotlib
   - jupyter
-  - pip
-  - pip:
-    - inequality
-    - black
+  - inequality
+  - black

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,4 @@ dependencies:
   - osmnx
   - momepy
   - jupyter
-  - pip
-  - pip:
-    - inequality
+  - inequality


### PR DESCRIPTION
All required dependencies are now on conda-forge, so no need to mix installation with pip.