### PR TITLE
REF: StreetProfile performance refactor

### DIFF
--- a/ci/travis/37-pysal.yaml
+++ b/ci/travis/37-pysal.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - geopandas
+  - geopandas=0.7
   - libpysal
   - networkx
   - tqdm

--- a/momepy/__init__.py
+++ b/momepy/__init__.py
@@ -1,13 +1,14 @@
-from .dimension import *
-from .intensity import *
-from .utils import *
-from .elements import *
-from .diversity import *
-from .distribution import *
-from .graph import *
-from .shape import *
-from .weights import *
 import momepy.datasets
+
+from .dimension import *
+from .distribution import *
+from .diversity import *
+from .elements import *
+from .graph import *
+from .intensity import *
+from .shape import *
+from .utils import *
+from .weights import *
 
 __author__ = "Martin Fleischmann"
 __author_email__ = "martin@martinfleischmann.net"

--- a/momepy/datasets/__init__.py
+++ b/momepy/datasets/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-
 __all__ = ["available", "get_path"]
 
 _module_path = os.path.dirname(__file__)

--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -538,13 +538,11 @@ class StreetProfile:
         heights_deviations_list = []
         openness_list = []
 
-        for idx, row in tqdm(left.iterrows(), total=left.shape[0]):
+        for shapely_line in tqdm(left.geometry, total=left.shape[0]):
             # list to hold all the point coords
             list_points = []
             # set the current distance to place the point
             current_dist = distance
-            # make shapely MultiLineString object
-            shapely_line = row.geometry
             # get the total length of the line
             line_length = shapely_line.length
             # append the starting coordinate to the list
@@ -648,8 +646,8 @@ class StreetProfile:
                                 )
                         if heights is not None:
                             indices = {}
-                            for idx, row in get_height.iterrows():
-                                dist = row.geometry.distance(Point(tick.coords[-1]))
+                            for idx, geom in get_height.geometry.iteritems():
+                                dist = geom.distance(Point(tick.coords[-1]))
                                 indices[idx] = dist
                             minim = min(indices, key=indices.get)
                             m_heights.append(right.loc[minim][heights])

--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -5,20 +5,18 @@
 # definitions of dimension characters
 
 import math
+from distutils.version import LooseVersion
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
 import scipy as sp
 from shapely.geometry import LineString, Point, Polygon
 from tqdm import tqdm
 
 from .shape import _make_circle
 
-from distutils.version import LooseVersion
-
 GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
-
 
 __all__ = [
     "Area",

--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -546,15 +546,17 @@ class StreetProfile:
             # get the total length of the line
             line_length = shapely_line.length
             # append the starting coordinate to the list
-            list_points.append(Point(list(shapely_line.coords)[0]))
+            list_points.append(list(shapely_line.coords)[0])
             # https://nathanw.net/2012/08/05/generating-chainage-distance-nodes-in-qgis/
             # while the current cumulative distance is less than the total length of the line
             while current_dist < line_length:
                 # use interpolate and increase the current distance
-                list_points.append(shapely_line.interpolate(current_dist))
+                list_points.append(
+                    list(shapely_line.interpolate(current_dist).coords)[0]
+                )
                 current_dist += distance
             # append end coordinate to the list
-            list_points.append(Point(list(shapely_line.coords)[-1]))
+            list_points.append(list(shapely_line.coords)[-1])
 
             ticks = []
             for num, pt in enumerate(list_points, 1):
@@ -564,8 +566,8 @@ class StreetProfile:
                     line_end_1 = self._getPoint1(pt, angle, tick_length / 2)
                     angle = self._getAngle(line_end_1, pt)
                     line_end_2 = self._getPoint2(line_end_1, angle, tick_length)
-                    tick1 = LineString([(line_end_1.x, line_end_1.y), (pt.x, pt.y)])
-                    tick2 = LineString([(line_end_2.x, line_end_2.y), (pt.x, pt.y)])
+                    tick1 = LineString([line_end_1, pt])
+                    tick2 = LineString([line_end_2, pt])
                     ticks.append([tick1, tick2])
 
                 # everything in between
@@ -576,18 +578,8 @@ class StreetProfile:
                     )
                     angle = self._getAngle(line_end_1, list_points[num])
                     line_end_2 = self._getPoint2(line_end_1, angle, tick_length)
-                    tick1 = LineString(
-                        [
-                            (line_end_1.x, line_end_1.y),
-                            (list_points[num].x, list_points[num].y),
-                        ]
-                    )
-                    tick2 = LineString(
-                        [
-                            (line_end_2.x, line_end_2.y),
-                            (list_points[num].x, list_points[num].y),
-                        ]
-                    )
+                    tick1 = LineString([line_end_1, list_points[num],])
+                    tick2 = LineString([line_end_2, list_points[num],])
                     ticks.append([tick1, tick2])
 
                 # end chainage
@@ -596,8 +588,8 @@ class StreetProfile:
                     line_end_1 = self._getPoint1(pt, angle, tick_length / 2)
                     angle = self._getAngle(line_end_1, pt)
                     line_end_2 = self._getPoint2(line_end_1, angle, tick_length)
-                    tick1 = LineString([(line_end_1.x, line_end_1.y), (pt.x, pt.y)])
-                    tick2 = LineString([(line_end_2.x, line_end_2.y), (pt.x, pt.y)])
+                    tick1 = LineString([line_end_1, pt])
+                    tick2 = LineString([line_end_2, pt])
                     ticks.append([tick1, tick2])
             # widths = []
             m_heights = []
@@ -688,25 +680,34 @@ class StreetProfile:
     # https://glenbambrick.com/tag/perpendicular/
     # angle between two points
     def _getAngle(self, pt1, pt2):
-        x_diff = pt2.x - pt1.x
-        y_diff = pt2.y - pt1.y
+        """
+        pt1, pt2 : tuple
+        """
+        x_diff = pt2[0] - pt1[0]
+        y_diff = pt2[1] - pt1[1]
         return math.degrees(math.atan2(y_diff, x_diff))
 
     # start and end points of chainage tick
     # get the first end point of a tick
     def _getPoint1(self, pt, bearing, dist):
+        """
+        pt : tuple
+        """
         angle = bearing + 90
         bearing = math.radians(angle)
-        x = pt.x + dist * math.cos(bearing)
-        y = pt.y + dist * math.sin(bearing)
-        return Point(x, y)
+        x = pt[0] + dist * math.cos(bearing)
+        y = pt[1] + dist * math.sin(bearing)
+        return (x, y)
 
     # get the second end point of a tick
     def _getPoint2(self, pt, bearing, dist):
+        """
+        pt : tuple
+        """
         bearing = math.radians(bearing)
-        x = pt.x + dist * math.cos(bearing)
-        y = pt.y + dist * math.sin(bearing)
-        return Point(x, y)
+        x = pt[0] + dist * math.cos(bearing)
+        y = pt[1] + dist * math.sin(bearing)
+        return (x, y)
 
 
 class WeightedCharacter:

--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -11,7 +11,6 @@ import pandas as pd
 import scipy as sp
 from shapely.geometry import LineString, Point, Polygon
 from tqdm import tqdm
-import pygeos
 
 from .shape import _make_circle
 
@@ -579,8 +578,8 @@ class StreetProfile:
                     )
                     angle = self._getAngle(line_end_1, list_points[num])
                     line_end_2 = self._getPoint2(line_end_1, angle, tick_length)
-                    tick1 = LineString([line_end_1, list_points[num],])
-                    tick2 = LineString([line_end_2, list_points[num],])
+                    tick1 = LineString([line_end_1, list_points[num]])
+                    tick2 = LineString([line_end_2, list_points[num]])
                     ticks.append([tick1, tick2])
 
                 # end chainage
@@ -598,15 +597,16 @@ class StreetProfile:
             rights = []
             for duo in ticks:
                 for ix, tick in enumerate(duo):
-                    true_int = right.iloc[sindex.query(tick, predicate="intersects")]
-                    if not true_int.empty:
+                    int_blg = right.iloc[sindex.query(tick, predicate="intersects")]
+                    if not int_blg.empty:
+                        true_int = int_blg.intersection(tick)
                         dist = true_int.distance(Point(tick.coords[-1]))
                         if ix == 0:
                             lefts.append(dist.min())
                         else:
                             rights.append(dist.min())
                         if heights is not None:
-                            m_heights.append(true_int.loc[dist.idxmin()][heights])
+                            m_heights.append(int_blg.loc[dist.idxmin()][heights])
 
             openness = (len(lefts) + len(rights)) / len(ticks * 2)
             openness_list.append(1 - openness)

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -13,7 +13,6 @@ from tqdm import tqdm  # progress bar
 
 from .utils import _azimuth
 
-
 __all__ = [
     "Orientation",
     "SharedWallsRatio",

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -6,15 +6,14 @@
 import operator
 
 import geopandas as gpd
+import libpysal
 import numpy as np
 import pandas as pd
 import shapely
-import libpysal
 from scipy.spatial import Voronoi
 from shapely.geometry import MultiPolygon, Point, Polygon
 from shapely.wkt import loads
 from tqdm import tqdm
-
 
 __all__ = ["buffered_limit", "Tessellation", "Blocks", "get_network_id", "get_node_id"]
 

--- a/momepy/weights.py
+++ b/momepy/weights.py
@@ -4,7 +4,6 @@
 import libpysal
 import numpy as np
 
-
 __all__ = ["DistanceBand", "sw_high"]
 
 

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -205,10 +205,10 @@ class TestDimensions:
         )
         assert results2.w[0] == 67.563796073073
         assert results2.wd[0] == 8.791875291865827
-        assert results2.h[0] == 23.756643356643362
-        assert results2.p[0] == 0.3516179483306353
+        assert results2.h[0] == 23.74545454545455
+        assert results2.p[0] == 0.3514523446813568
         assert results2.o[0] == 0.5535714285714286
-        assert results2.hd[0] == 5.526848034418866
+        assert results2.hd[0] == 5.5188633970914065
 
         results3 = mm.StreetProfile(self.df_streets, self.df_buildings)
         assert results3.w[0] == 46.7290758769204


### PR DESCRIPTION
Refactor of `StreetProfile` to get better performance. There's still space for more work.

Benchmark:
```
       before           after         ratio
     [05ca8623]       [fece9f90]
     <master>         <profile_perf~3>
-      3.17±0.01s       1.18±0.05s     0.37  bench_dimension.TimeDimension.time_StreetProfile
```

I've also fixed a bug I did not know about which sometimes picked incorrect height.