### PR TITLE
PERF: performance improvements in elements module

### DIFF
--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -824,6 +824,7 @@ def _split_lines(polygon, distance):
     list_points = []
     current_dist = distance  # set the current distance to place the point
 
+    # TODO: use pygeos interpolate
     boundary = polygon.boundary  # make shapely MultiLineString object
     if boundary.type == "LineString":
         line_length = boundary.length  # get the total length of the line

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -734,41 +734,22 @@ def get_network_id(left, right, network_id, min_size=100):
     print("Generating rtree...")
     idx = right.sindex
 
+    # TODO: use sjoin nearest once done
     result = []
-    # for p in tqdm(buildings_c.geometry, total=buildings_c.shape[0], desc="Snapping"):
-    #     pbox = (p.x - min_size, p.y - min_size, p.x + min_size, p.y + min_size)
-    #     hits = list(idx.intersection(pbox))
-    #     d = INFTY
-    #     nid = None
-    #     for h in hits:
-    #         new_d = p.distance(right.geometry.iloc[h])
-    #         if d >= new_d:
-    #             d = new_d
-    #             nid = right[network_id].iloc[h]
-    #     if nid is None:
-    #         result.append(np.nan)
-    #     else:
-    #         result.append(nid)
-
-    # bounds = buildings_c.bounds
-    # bounds[["minx", "miny"]] = bounds[["minx", "miny"]] - min_size
-    # bounds[["maxx", "maxy"]] = bounds[["maxx", "maxy"]] + min_size
-    # for p, pbox in zip(buildings_c.geometry, bounds.values):
-    #     hits = list(idx.intersection(pbox))
-    #     dist = right.iloc[hits].distance(p)
-    #     if dist.empty:
-    #         result.append(np.nan)
-    #     else:
-    #         result.append(right[network_id].loc[dist.idxmin()])
-
     for p in tqdm(buildings_c.geometry, total=buildings_c.shape[0], desc="Snapping"):
         pbox = (p.x - min_size, p.y - min_size, p.x + min_size, p.y + min_size)
         hits = list(idx.intersection(pbox))
-        dist = right.iloc[hits].distance(p)
-        if dist.empty:
+        d = INFTY
+        nid = None
+        for h in hits:
+            new_d = p.distance(right.geometry.iloc[h])
+            if d >= new_d:
+                d = new_d
+                nid = right[network_id].iloc[h]
+        if nid is None:
             result.append(np.nan)
         else:
-            result.append(right[network_id].loc[dist.idxmin()])
+            result.append(nid)
 
     series = pd.Series(result)
 

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -141,7 +141,7 @@ class Tessellation:
         self.shrink = shrink
         self.segment = segment
 
-        objects = gdf.set_index(unique_id)
+        objects = gdf.copy()
 
         centre = self._get_centre(objects)
         objects["geometry"] = objects["geometry"].translate(
@@ -155,7 +155,7 @@ class Tessellation:
         )
 
         objects = objects.explode()
-        objects.reset_index(inplace=True, drop=True)
+        objects = objects.set_index(unique_id)
 
         print("Discretization...")
         objects["geometry"] = objects["geometry"].apply(self._densify, segment=segment)

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -735,10 +735,34 @@ def get_network_id(left, right, network_id, min_size=100):
     idx = right.sindex
 
     result = []
-    bounds = buildings_c.bounds
-    bounds[["minx", "miny"]] = bounds[["minx", "miny"]] - min_size
-    bounds[["maxx", "maxy"]] = bounds[["maxx", "maxy"]] + min_size
-    for p, pbox in zip(buildings_c.geometry, bounds.values):
+    # for p in tqdm(buildings_c.geometry, total=buildings_c.shape[0], desc="Snapping"):
+    #     pbox = (p.x - min_size, p.y - min_size, p.x + min_size, p.y + min_size)
+    #     hits = list(idx.intersection(pbox))
+    #     d = INFTY
+    #     nid = None
+    #     for h in hits:
+    #         new_d = p.distance(right.geometry.iloc[h])
+    #         if d >= new_d:
+    #             d = new_d
+    #             nid = right[network_id].iloc[h]
+    #     if nid is None:
+    #         result.append(np.nan)
+    #     else:
+    #         result.append(nid)
+
+    # bounds = buildings_c.bounds
+    # bounds[["minx", "miny"]] = bounds[["minx", "miny"]] - min_size
+    # bounds[["maxx", "maxy"]] = bounds[["maxx", "maxy"]] + min_size
+    # for p, pbox in zip(buildings_c.geometry, bounds.values):
+    #     hits = list(idx.intersection(pbox))
+    #     dist = right.iloc[hits].distance(p)
+    #     if dist.empty:
+    #         result.append(np.nan)
+    #     else:
+    #         result.append(right[network_id].loc[dist.idxmin()])
+
+    for p in tqdm(buildings_c.geometry, total=buildings_c.shape[0], desc="Snapping"):
+        pbox = (p.x - min_size, p.y - min_size, p.x + min_size, p.y + min_size)
         hits = list(idx.intersection(pbox))
         dist = right.iloc[hits].distance(p)
         if dist.empty:

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -580,7 +580,7 @@ class Blocks:
             new_geom.append(cell.difference(possible_matches.unary_union))
 
         print("Defining adjacency...")
-        blocks_gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries(new_geom))
+        blocks_gdf = gpd.GeoDataFrame(geometry=new_geom)
         blocks_gdf = blocks_gdf.explode().reset_index(drop=True)
 
         spatial_weights = libpysal.weights.Queen.from_dataframe(
@@ -597,22 +597,18 @@ class Blocks:
             else:
                 to_join = [idx]  # list of indices which should be joined together
                 neighbours = []  # list of neighbours
-                weights = spatial_weights.neighbors[
+                neighbours += spatial_weights.neighbors[
                     idx
                 ]  # neighbours from spatial weights
-                for w in weights:
-                    neighbours.append(w)  # make a list from weigths
 
                 for n in neighbours:
                     while (
                         n not in to_join
                     ):  # until there is some neighbour which is not in to_join
                         to_join.append(n)
-                        weights = spatial_weights.neighbors[n]
-                        for w in weights:
-                            neighbours.append(
-                                w
-                            )  # extend neighbours by neighbours of neighbours :)
+                        neighbours += spatial_weights.neighbors[
+                            n
+                        ]  # extend neighbours by neighbours of neighbours :)
                 for b in to_join:
                     patches[b] = jID  # fill dict with values
                 jID = jID + 1

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -572,9 +572,12 @@ class Blocks:
         for ix, cell in tqdm(
             cells_copy.geometry.iteritems(), total=cells_copy.shape[0]
         ):
-            possible_matches_index = list(streets_index.intersection(cell.bounds))
+            if GPD_08:
+                possible_matches_index = streets_index.query(cell)
+            else:
+                possible_matches_index = list(streets_index.intersection(cell.bounds))
             possible_matches = street_buff.iloc[possible_matches_index]
-            new_geom.append(cell.difference(possible_matches.geometry.unary_union))
+            new_geom.append(cell.difference(possible_matches.unary_union))
 
         print("Defining adjacency...")
         blocks_gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries(new_geom))


### PR DESCRIPTION
Some code cleanup and performance-focus refactoring in elements module. Most of it will affect only larger df. `get_node_id` also small:

```
374±8ms         99.4±5ms     0.27  bench_elements.TimeElements.time_get_node_id
```