### PR TITLE
PERF: refactor SharedWallsRatio

### DIFF
--- a/benchmarks/bench_distribution.py
+++ b/benchmarks/bench_distribution.py
@@ -27,7 +27,7 @@ class TimeDistribution:
         mm.Orientation(self.df_buildings)
 
     def time_SharedWallsRatio(self):
-        mm.SharedWallsRatio(self.df_buildings, "uID")
+        mm.SharedWallsRatio(self.df_buildings)
 
     def time_StreetAlignment(self):
         mm.StreetAlignment(

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -168,22 +168,36 @@ class SharedWallsRatio:
             unique_id = "mm_uid"
         self.id = gdf[unique_id]
 
-        gdf["_bounds"] = gdf.geometry.bounds.apply(list, axis=1)
+        # gdf["_bounds"] = gdf.geometry.bounds.apply(list, axis=1)
+        # for i, row in tqdm(
+        #     enumerate(
+        #         gdf[[perimeters, "_bounds", gdf._geometry_column_name]].itertuples()
+        #     ),
+        #     total=gdf.shape[0],
+        # ):
+        #     neighbors = list(self.sindex.intersection(row[2]))
+        #     neighbors.remove(i)
+
+        #     # if no neighbour exists
+        #     length = 0
+        #     if not neighbors:
+        #         results_list.append(0)
+        #     else:
+        #         length = gdf.iloc[neighbors].intersection(row[3]).length.sum()
+        #         results_list.append(length / row[1])
+
+        inp, res = self.sindex.query_bulk(gdf.geometry)
         for i, row in tqdm(
-            enumerate(
-                gdf[[perimeters, "_bounds", gdf._geometry_column_name]].itertuples()
-            ),
+            enumerate(gdf[[perimeters, gdf._geometry_column_name]].itertuples()),
             total=gdf.shape[0],
         ):
-            neighbors = list(self.sindex.intersection(row[2]))
+            neighbors = list(res[inp == i])
             neighbors.remove(i)
 
-            # if no neighbour exists
-            length = 0
             if not neighbors:
                 results_list.append(0)
             else:
-                length = gdf.iloc[neighbors].intersection(row[3]).length.sum()
+                length = gdf.iloc[neighbors].intersection(row[2]).length.sum()
                 results_list.append(length / row[1])
 
         self.series = pd.Series(results_list, index=gdf.index)

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -156,7 +156,7 @@ class SharedWallsRatio:
         else:
             self.perimeters = perimeters
 
-        inp, res = self.sindex.query_bulk(gdf.geometry, predicate="intersects")
+        inp, res = gdf.sindex.query_bulk(gdf.geometry, predicate="intersects")
         left = gdf.geometry.take(inp).reset_index(drop=True)
         right = gdf.geometry.take(res).reset_index(drop=True)
         intersections = left.intersection(right).length

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -7,12 +7,16 @@
 import math
 import statistics
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
+import geopandas as gpd
 from tqdm import tqdm  # progress bar
 
 from .utils import _azimuth
+
+GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
 
 __all__ = [
     "Orientation",
@@ -142,6 +146,10 @@ class SharedWallsRatio:
     """
 
     def __init__(self, gdf, unique_id=None, perimeters=None):
+        if not GPD_08:
+            raise ImportError(
+                "The 'geopandas' >= 0.8.0 package is required to use SharedWallsRatio."
+            )
         if unique_id:
             warnings.warn(
                 "unique_id is deprecated and will be removed in v0.4.", FutureWarning,

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -29,20 +29,18 @@ class TestDistribution:
         assert self.df_streets["orient"][0] == pytest.approx(check)
 
     def test_SharedWallsRatio(self):
-        self.df_buildings["swr"] = mm.SharedWallsRatio(self.df_buildings, "uID").series
-        self.df_buildings["swr_uid"] = mm.SharedWallsRatio(
-            self.df_buildings, range(len(self.df_buildings))
-        ).series
+        self.df_buildings["swr"] = mm.SharedWallsRatio(self.df_buildings).series
         self.df_buildings["swr_array"] = mm.SharedWallsRatio(
-            self.df_buildings, "uID", self.df_buildings.geometry.length
+            self.df_buildings, perimeters=self.df_buildings.geometry.length
         ).series
         nonconsecutive = self.df_buildings.drop(2)
-        result = mm.SharedWallsRatio(nonconsecutive, "uID").series
+        result = mm.SharedWallsRatio(nonconsecutive).series
         check = 0.3424804411228673
         assert self.df_buildings["swr"][10] == check
-        assert self.df_buildings["swr_uid"][10] == check
         assert self.df_buildings["swr_array"][10] == check
         assert result[10] == check
+        with pytest.warns(FutureWarning):
+            mm.SharedWallsRatio(self.df_buildings, "uID")
 
     def test_StreetAlignment(self):
         self.df_buildings["orient"] = orient = mm.Orientation(self.df_buildings).series

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,8 +1,12 @@
+from distutils.version import LooseVersion
+
 import geopandas as gpd
 import momepy as mm
 import numpy as np
 import pytest
 from libpysal.weights import Queen
+
+GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
 
 
 class TestDistribution:
@@ -28,6 +32,7 @@ class TestDistribution:
         check = 40.7607
         assert self.df_streets["orient"][0] == pytest.approx(check)
 
+    @pytest.mark.skipif(not GPD_08, reason="requires geopandas > 0.7")
     def test_SharedWallsRatio(self):
         self.df_buildings["swr"] = mm.SharedWallsRatio(self.df_buildings).series
         self.df_buildings["swr_array"] = mm.SharedWallsRatio(


### PR DESCRIPTION
Using `sindex.query_bulk` and fully vectorized operations. Requires geopandas 0.8+ as compat layer would be essentially reimplementing the same algorithm.

Bechmark from `185.296ms` to `37.5±1ms`.