### PR TITLE
PERF: perfomance enhancements in sw_high

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,22 +23,6 @@ class TestUtils:
         with pytest.raises(ValueError):
             mm.datasets.get_path("sffgkt")
 
-    def test_sw_high(self):
-        first_order = libpysal.weights.Queen.from_dataframe(self.df_tessellation)
-        from_sw = mm.sw_high(2, gdf=None, weights=first_order)
-        from_df = mm.sw_high(2, gdf=self.df_tessellation)
-        rook = mm.sw_high(2, gdf=self.df_tessellation, contiguity="rook")
-        check = [133, 134, 111, 112, 113, 114, 115, 121, 125]
-        assert from_sw.neighbors[0] == check
-        assert from_df.neighbors[0] == check
-        assert rook.neighbors[0] == check
-
-        with pytest.raises(AttributeError):
-            mm.sw_high(2, gdf=None, weights=None)
-
-        with pytest.raises(ValueError):
-            mm.sw_high(2, gdf=self.df_tessellation, contiguity="nonexistent")
-
     def test_gdf_to_nx(self):
         nx = mm.gdf_to_nx(self.df_streets)
         assert nx.number_of_nodes() == 29

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -17,10 +17,10 @@ class TestWeights:
         from_sw = mm.sw_high(2, gdf=None, weights=first_order)
         from_df = mm.sw_high(2, gdf=self.df_tessellation)
         rook = mm.sw_high(2, gdf=self.df_tessellation, contiguity="rook")
-        check = [133, 134, 111, 112, 113, 114, 115, 121, 125]
-        assert from_sw.neighbors[0] == check
-        assert from_df.neighbors[0] == check
-        assert rook.neighbors[0] == check
+        check = sorted([133, 134, 111, 112, 113, 114, 115, 121, 125])
+        assert sorted(from_sw.neighbors[0]) == check
+        assert sorted(from_df.neighbors[0]) == check
+        assert sorted(rook.neighbors[0]) == check
 
         with pytest.raises(AttributeError):
             mm.sw_high(2, gdf=None, weights=None)


### PR DESCRIPTION
Use part of adapted libpysal code directly. Will be changed once `libpysal.higher.order` returns <= k neighbors.