### PR TITLE
CI: pin black

### DIFF
--- a/ci/travis/latest-mc.yaml
+++ b/ci/travis/latest-mc.yaml
@@ -17,4 +17,4 @@ dependencies:
   - matplotlib
   - jupyter
   - inequality
-  - black
+  - black=19


### PR DESCRIPTION
Black has a bug in the release 20, causing unfixable failure of style check. Pinning until the fix is released. 