### PR TITLE
ENH: vectorised remove_false_nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+Version 0.4.0 (TBD)
+-------------------
+
+Requirements:
+
+- momepy now requires GeoPandas 0.8 or newer
+- momepy now requires pygeos
+
+API changes:
+
+- ``network_false_nodes`` is now deprecated. Use new ``remove_false_nodes`` instead.
+
+Enhancements:
+
+- New performant algorithm ``remove_false_nodes`` to remove nodes of a degree 2 of a LineString network.
+
+
 Version 0.3.0 (July 29, 2020)
 -----------------------------
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -2,22 +2,17 @@
     // The version of the config file format.  Do not change, unless
     // you know what you are doing.
     "version": 1,
-
     // The name of the project being benchmarked
     "project": "momepy",
-
     // The project's homepage
     "project_url": "http://momepy.org/",
-
     // The URL or local path of the source code repository for the
     // project being benchmarked
     "repo": ".",
-
     // The Python project's subdirectory in your repo.  If missing or
     // the empty string, the project is assumed to be located at the root
     // of the repository.
     // "repo_subdir": "",
-
     // Customizable commands for building, installing, and
     // uninstalling the project. See asv.conf.json documentation.
     //
@@ -27,41 +22,36 @@
     //     "python setup.py build",
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
-
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
     // "branches": ["master"], // for git
     // "branches": ["default"],    // for mercurial
-
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as
     // ".git" (if local).
     // "dvcs": "git",
-
     // The tool to use to create environments.  May be "conda",
     // "virtualenv" or other value depending on the plugins in use.
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
     "environment_type": "conda",
-    "conda_channels": ["conda-forge", "defaults"],
-
+    "conda_channels": [
+        "conda-forge",
+        "defaults"
+    ],
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
     //"install_timeout": 600,
-
     // the base URL to show a commit for the project.
     "show_commit_url": "http://github.com/martinfleis/momepy/commit/",
-
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     // "pythons": ["2.7", "3.6"],
-
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order
     // "conda_channels": ["conda-forge", "defaults"],
-
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list or empty string indicates to just test against the default
@@ -79,9 +69,9 @@
         "networkx": [],
         "tqdm": [],
         "mapclassify": [],
-        "inequality": []
+        "inequality": [],
+        "pygeos": []
     },
-
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional
     // key-value pairs to include/exclude.
@@ -114,31 +104,24 @@
     //     // additional env if run on windows+conda
     //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
     // ],
-
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
     // "benchmark_dir": "benchmarks",
-
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
     "env_dir": ".asv/env",
-
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
     "results_dir": ".asv/results",
-
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
     "html_dir": ".asv/html",
-
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8,
-
     // `asv` will cache results of the recent builds in each
     // environment, making them faster to install next time.  This is
     // the number of builds to keep, per environment.
     // "build_cache_size": 2,
-
     // The commits after which the regression search in `asv publish`
     // should start looking for regressions. Dictionary whose keys are
     // regexps matching to benchmark names, and values corresponding to
@@ -151,7 +134,6 @@
     //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
     //    "another_benchmark": null,   // Skip regression detection altogether
     // },
-
     // The thresholds for relative change in results, after which `asv
     // publish` starts reporting regressions. Dictionary of the same
     // form as in ``regressions_first_commits``, with values

--- a/benchmarks/bench_utils.py
+++ b/benchmarks/bench_utils.py
@@ -39,6 +39,9 @@ class TimeUtils:
     def time_network_false_nodes(self):
         mm.network_false_nodes(self.false_network)
 
+    def time_remove_false_nodes(self):
+        mm.remove_false_nodes(self.false_network)
+
     def time_snap_street_network_edge(self):
         mm.snap_street_network_edge(
             self.df_streets, self.df_buildings, 20, self.df_tessellation, 70

--- a/ci/travis/37-pysal.yaml
+++ b/ci/travis/37-pysal.yaml
@@ -13,3 +13,4 @@ dependencies:
   - pysal
   - osmnx
   - black
+  - pygeos

--- a/ci/travis/37-pysal.yaml
+++ b/ci/travis/37-pysal.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - geopandas=0.7
+  - geopandas=0.8
   - libpysal
   - networkx
   - tqdm

--- a/ci/travis/dev.yaml
+++ b/ci/travis/dev.yaml
@@ -16,3 +16,4 @@ dependencies:
   - black
   - nose
   - inequality
+  - pygeos

--- a/ci/travis/latest-mc.yaml
+++ b/ci/travis/latest-mc.yaml
@@ -18,3 +18,4 @@ dependencies:
   - jupyter
   - inequality
   - black=19
+  - pygeos

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,7 +144,7 @@ utilities
    CheckTessellationInput
    gdf_to_nx
    limit_range
-   network_false_nodes
+   remove_false_nodes
    nx_to_gdf
    preprocess
    snap_street_network_edge

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - momepy
   - jupyter
   - inequality
+  - pygeos

--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -372,7 +372,7 @@ def simpson_diversity(data, bins=None, categorical=False, categories=None):
         \\lambda=\\sum_{i=1}^{R} p_{i}^{2}
 
     Formula adapted from https://gist.github.com/martinjc/f227b447791df8c90568.
-    
+
     Parameters
     ----------
     data : GeoDataFrame
@@ -388,7 +388,7 @@ def simpson_diversity(data, bins=None, categorical=False, categories=None):
     -------
     float
         Simpson's diversity index
-    
+
     See also
     --------
     momepy.Simpson : Calculates the Simpson\'s diversity index of values within neighbours
@@ -661,7 +661,7 @@ def shannon_diversity(data, bins=None, categorical=False, categories=None):
         \\lambda=\\sum_{i=1}^{R} p_{i}^{2}
 
     Formula adapted from https://gist.github.com/audy/783125
-    
+
     Parameters
     ----------
     data : GeoDataFrame
@@ -677,7 +677,7 @@ def shannon_diversity(data, bins=None, categorical=False, categories=None):
     -------
     float
         Shannon's diversity index
-    
+
     See also
     --------
     momepy.Shannon : Calculates the Shannon's diversity index of values within neighbours

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -4,7 +4,6 @@
 import collections
 import math
 import operator
-import warnings
 
 import geopandas as gpd
 import libpysal
@@ -312,13 +311,14 @@ def preprocess(
     buildings, size=30, compactness=0.2, islands=True, loops=2, verbose=True
 ):
     """
-    Preprocesses building geometry to eliminate additional structures being single features.
+    Preprocesses building geometry to eliminate additional structures being single
+    features.
 
     Certain data providers (e.g. Ordnance Survey in GB) do not provide building geometry
-    as one feature, but divided into different features depending their level (if they are
-    on ground floor or not - passages, overhangs). Ideally, these features should share
-    one building ID on which they could be dissolved. If this is not the case, series of
-    steps needs to be done to minimize errors in morphological analysis.
+    as one feature, but divided into different features depending their level (if they
+    are on ground floor or not - passages, overhangs). Ideally, these features should
+    share one building ID on which they could be dissolved. If this is not the case,
+    series of steps needs to be done to minimize errors in morphological analysis.
 
     This script attempts to preprocess such geometry based on several condidions:
     If feature area is smaller than set size it will be a) deleted if it does not
@@ -481,6 +481,7 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
     -------
     gdf : GeoDataFrame, GeoSeries
     """
+    import warnings
 
     warnings.warn(
         "network_false_nodes() is deprecated and will be removed in momepy 0.5.0. "
@@ -783,7 +784,8 @@ def snap_street_network_edge(
     # function extending line to closest object within set distance
     def extend_line(tolerance, idx):
         """
-        Extends a line geometry withing GeoDataFrame to snap on itself withing tolerance.
+        Extends a line geometry withing GeoDataFrame to snap on itself withing 
+        tolerance.
         """
         if Point(l_coords[-2]).distance(Point(l_coords[-1])) <= 0.001:
             if len(l_coords) > 2:
@@ -845,10 +847,12 @@ def snap_street_network_edge(
         else:
             return False
 
-    # function extending line to closest object within set distance to edge defined by tessellation
+    # function extending line to closest object within set distance to edge defined by
+    # tessellation
     def extend_line_edge(tolerance, idx):
         """
-        Extends a line geometry withing GeoDataFrame to snap on the boundary of tessellation withing tolerance.
+        Extends a line geometry withing GeoDataFrame to snap on the boundary of 
+        tessellation withing tolerance.
         """
         if Point(l_coords[-2]).distance(Point(l_coords[-1])) <= 0.001:
             if len(l_coords) > 2:
@@ -931,7 +935,8 @@ def snap_street_network_edge(
     ):
 
         l_coords = list(line.coords)
-        # network_w = network.drop(idx, axis=0)['geometry']  # ensure that it wont intersect itself
+        # network_w = network.drop(idx, axis=0)['geometry']  # ensure that it wont
+        # intersect itself
         start = Point(l_coords[0])
         end = Point(l_coords[-1])
 
@@ -1000,8 +1005,8 @@ class CheckTessellationInput:
     have to be fixed prior Tessellation. Features which will split will cause issues
     only sometimes, so
     should be checked and fixed if necessary. Features which will collapse could
-    be
-    ignored, but they will have to excluded from next steps of tessellation-based analysis.
+    be ignored, but they will have to excluded from next steps of 
+    tessellation-based analysis.
 
     Parameters
     ----------

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import collections
 import math
 import operator
-from distutils.version import LooseVersion
+import warnings
 
 import geopandas as gpd
 import libpysal
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pygeos
 import shapely
 from shapely.geometry import LineString, Point
 from tqdm import tqdm
 
 from .shape import CircularCompactness
-
-GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
 
 __all__ = [
     "unique_id",
@@ -25,6 +25,7 @@ __all__ = [
     "limit_range",
     "preprocess",
     "network_false_nodes",
+    "remove_false_nodes",
     "snap_street_network_edge",
     "CheckTessellationInput",
 ]
@@ -480,6 +481,13 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
     -------
     gdf : GeoDataFrame, GeoSeries
     """
+
+    warnings.warn(
+        "network_false_nodes() is deprecated and will be removed in momepy 0.5.0. "
+        "Use remove_false_nodes() instead.",
+        FutureWarning,
+    )
+
     if not isinstance(gdf, (gpd.GeoSeries, gpd.GeoDataFrame)):
         raise TypeError(
             "'gdf' should be GeoDataFrame or GeoSeries, got {}".format(type(gdf))
@@ -504,22 +512,8 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
         start = Point(l_coords[0]).buffer(tolerance)
         end = Point(l_coords[-1]).buffer(tolerance)
 
-        if GPD_08:
-            real_first_matches = sindex.query(start, predicate="intersects")
-            real_second_matches = sindex.query(end, predicate="intersects")
-        else:
-            # find out whether ends of the line are connected or not
-            possible_first_index = list(sindex.intersection(start.bounds))
-            possible_first_matches = streets.iloc[possible_first_index]
-            real_first_matches = possible_first_matches[
-                possible_first_matches.intersects(start)
-            ]
-
-            possible_second_index = list(sindex.intersection(end.bounds))
-            possible_second_matches = streets.iloc[possible_second_index]
-            real_second_matches = possible_second_matches[
-                possible_second_matches.intersects(end)
-            ]
+        real_first_matches = sindex.query(start, predicate="intersects")
+        real_second_matches = sindex.query(end, predicate="intersects")
 
         if len(real_first_matches) == 2:
             false_xy.append(
@@ -532,10 +526,7 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
 
     false_unique = list(set(false_xy))
     x, y = zip(*false_unique)
-    if GPD_08:
-        points = gpd.points_from_xy(x, y).buffer(tolerance)
-    else:
-        points = gpd.GeoSeries(gpd.points_from_xy(x, y)).buffer(tolerance)
+    points = gpd.points_from_xy(x, y).buffer(tolerance)
 
     geoms = streets
     idx = max(geoms.index) + 1
@@ -544,13 +535,8 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
         zip(x, y, points), desc="Merging segments", total=len(x), disable=not verbose
     ):
 
-        if GPD_08:
-            predic = geoms.sindex.query(point, predicate="intersects")
-            matches = geoms.iloc[predic].geometry
-        else:
-            pos = list(geoms.sindex.intersection(point.bounds))
-            mat = geoms.iloc[pos]
-            matches = mat[mat.intersects(point)].geometry
+        predic = geoms.sindex.query(point, predicate="intersects")
+        matches = geoms.iloc[predic].geometry
 
         try:
             snap = shapely.ops.snap(matches.iloc[0], matches.iloc[1], tolerance,)
@@ -584,6 +570,85 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
         streets.crs = gdf.crs
         return streets
     return streets
+
+
+def remove_false_nodes(gdf):
+    """
+    Clean topology of existing LineString geometry by removal of nodes of degree 2.
+
+    Parameters
+    ----------
+    gdf : GeoDataFrame, GeoSeries, array of pygeos geometries
+        (Multi)LineString data of street network
+
+    Returns
+    -------
+    gdf : GeoDataFrame, GeoSeries
+    """
+    if isinstance(gdf, (gpd.GeoDataFrame, gpd.GeoSeries)):
+        # explode to avoid MultiLineStrings
+        # double reset index due to the bug in GeoPandas explode
+        df = gdf.reset_index(drop=True).explode().reset_index(drop=True)
+
+        # get underlying pygeos geometry
+        geom = df.geometry.values.data
+    else:
+        geom = gdf
+
+    # extract array of coordinates and number per geometry
+    coords = pygeos.get_coordinates(geom)
+    indices = pygeos.get_num_coordinates(geom)
+
+    # generate a list of start and end coordinates and create point geometries
+    edges = [0]
+    i = 0
+    for ind in indices:
+        ix = i + ind
+        edges.append(ix - 1)
+        edges.append(ix)
+        i = ix
+    edges = edges[:-1]
+    points = pygeos.points(np.unique(coords[edges], axis=0))
+
+    # query LineString geometry to identify points intersecting 2 geometries
+    tree = pygeos.STRtree(geom)
+    inp, res = tree.query_bulk(points, predicate="intersects")
+    unique, counts = np.unique(inp, return_counts=True)
+    merge = res[np.isin(inp, unique[counts == 2])]
+
+    if len(merge) > 0:
+        # filter duplications and create a dictionary with indication of components to
+        # be merged together
+        dups = [item for item, count in collections.Counter(merge).items() if count > 1]
+        split = np.split(merge, len(merge) / 2)
+        components = {}
+        for i, a in enumerate(split):
+            if a[0] in dups or a[1] in dups:
+                if a[0] in components.keys():
+                    i = components[a[0]]
+                elif a[1] in components.keys():
+                    i = components[a[1]]
+            components[a[0]] = i
+            components[a[1]] = i
+
+        # iterate through components and create new geometries
+        new = []
+        for c in set(components.values()):
+            keys = []
+            for item in components.items():
+                if item[1] == c:
+                    keys.append(item[0])
+            new.append(pygeos.line_merge(pygeos.union_all(geom[keys])))
+
+        # remove incorrect geometries and append fixed versions
+        df = df.drop(merge)
+        final = gpd.GeoSeries(new).explode().reset_index(drop=True)
+        if isinstance(gdf, gpd.GeoDataFrame):
+            return df.append(
+                gpd.GeoDataFrame({df.geometry.name: final}, geometry=df.geometry.name),
+                ignore_index=True,
+            )
+        return df.append(final, ignore_index=True)
 
 
 def snap_street_network_edge(

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -559,7 +559,6 @@ def network_false_nodes(gdf, tolerance=0.1, precision=3, verbose=True):
 
             geoms = geoms.drop(matches.index)
         except (IndexError, ValueError):
-            import warnings
 
             warnings.warn(
                 "An exception during merging occured. "

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,11 @@ setup(
         "Topic :: Scientific/Engineering :: GIS",
     ],
     install_requires=[
-        "geopandas>=0.5.1",
+        "geopandas>=0.8.0",
         "networkx>=2.3",
         "libpysal>=4.1.0",
         "tqdm>=4.25.0",
+        "pygeos",
     ],
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,19 +106,43 @@ class TestUtils:
         test_file_path2 = mm.datasets.get_path("tests")
         self.false_network = gpd.read_file(test_file_path2, layer="network")
         self.false_network["vals"] = range(len(self.false_network))
-        fixed = mm.network_false_nodes(self.false_network)
+        with pytest.warns(FutureWarning):
+            fixed = mm.network_false_nodes(self.false_network)
         assert len(fixed) == 56
         assert isinstance(fixed, gpd.GeoDataFrame)
         assert self.false_network.crs.equals(fixed.crs)
         assert sorted(self.false_network.columns) == sorted(fixed.columns)
-        fixed_series = mm.network_false_nodes(self.false_network.geometry)
+        with pytest.warns(FutureWarning):
+            fixed_series = mm.network_false_nodes(self.false_network.geometry)
         assert len(fixed_series) == 56
         assert isinstance(fixed_series, gpd.GeoSeries)
         assert self.false_network.crs.equals(fixed_series.crs)
         with pytest.raises(TypeError):
             mm.network_false_nodes(list())
         multiindex = self.false_network.explode()
-        fixed_multiindex = mm.network_false_nodes(multiindex)
+        with pytest.warns(FutureWarning):
+            fixed_multiindex = mm.network_false_nodes(multiindex)
+        assert len(fixed_multiindex) == 56
+        assert isinstance(fixed, gpd.GeoDataFrame)
+        assert sorted(self.false_network.columns) == sorted(fixed.columns)
+
+    def test_remove_false_nodes(self):
+        test_file_path2 = mm.datasets.get_path("tests")
+        self.false_network = gpd.read_file(test_file_path2, layer="network")
+        self.false_network["vals"] = range(len(self.false_network))
+        fixed = mm.remove_false_nodes(self.false_network)
+        assert len(fixed) == 56
+        assert isinstance(fixed, gpd.GeoDataFrame)
+        assert self.false_network.crs.equals(fixed.crs)
+        assert sorted(self.false_network.columns) == sorted(fixed.columns)
+        fixed_series = mm.remove_false_nodes(self.false_network.geometry)
+        assert len(fixed_series) == 56
+        assert isinstance(fixed_series, gpd.GeoSeries)
+        # assert self.false_network.crs.equals(fixed_series.crs) GeoPandas 0.8 BUG
+        with pytest.raises(TypeError):
+            mm.network_false_nodes(list())
+        multiindex = self.false_network.explode()
+        fixed_multiindex = mm.remove_false_nodes(multiindex)
         assert len(fixed_multiindex) == 56
         assert isinstance(fixed, gpd.GeoDataFrame)
         assert sorted(self.false_network.columns) == sorted(fixed.columns)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -139,8 +139,6 @@ class TestUtils:
         assert len(fixed_series) == 56
         assert isinstance(fixed_series, gpd.GeoSeries)
         # assert self.false_network.crs.equals(fixed_series.crs) GeoPandas 0.8 BUG
-        with pytest.raises(TypeError):
-            mm.network_false_nodes(list())
         multiindex = self.false_network.explode()
         fixed_multiindex = mm.remove_false_nodes(multiindex)
         assert len(fixed_multiindex) == 56


### PR DESCRIPTION
Current `network_false_nodes` is being replaced by new vectorised function `remove_false_nodes`. This change adds `pygeos` as momepy's dependency.

The algorithm has been written as a part of [Urban Grammar AI research project](https://urbangrammarai.github.io).

