### PR TITLE
BUG: don't change gdf in DistanceBand + cleanup

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -5,19 +5,15 @@
 # definitions of dimension characters
 
 import math
-from distutils.version import LooseVersion
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pygeos
 import scipy as sp
-from shapely.geometry import LineString, Point
 from tqdm import tqdm
 
 from .shape import _circle_radius
 
-GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
 
 __all__ = [
     "Area",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-geopandas>=0.5.1
+geopandas>=0.8.0
 networkx>=2.3
 libpysal>=4.1.0
-pandas>=0.24
 tqdm>=4.25
+pygeos

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -6,8 +6,6 @@ import numpy as np
 import pytest
 from libpysal.weights import Queen
 
-GPD_08 = str(gpd.__version__) >= LooseVersion("0.8.0")
-
 
 class TestDistribution:
     def setup_method(self):
@@ -32,7 +30,6 @@ class TestDistribution:
         check = 40.7607
         assert self.df_streets["orient"][0] == pytest.approx(check)
 
-    @pytest.mark.skipif(not GPD_08, reason="requires geopandas > 0.7")
     def test_SharedWalls(self):
         self.df_buildings["swr"] = mm.SharedWalls(self.df_buildings).series
         nonconsecutive = self.df_buildings.drop(2)
@@ -41,7 +38,6 @@ class TestDistribution:
         assert self.df_buildings["swr"][10] == check
         assert result[10] == check
 
-    @pytest.mark.skipif(not GPD_08, reason="requires geopandas > 0.7")
     def test_SharedWallsRatio(self):
         self.df_buildings["swr"] = mm.SharedWallsRatio(self.df_buildings).series
         self.df_buildings["swr_array"] = mm.SharedWallsRatio(
@@ -154,7 +150,6 @@ class TestDistribution:
             .any()
         )
 
-    @pytest.mark.skipif(not GPD_08, reason="requires geopandas > 0.7")
     def test_NeighboringStreetOrientationDeviation(self):
         self.df_streets["dev"] = mm.NeighboringStreetOrientationDeviation(
             self.df_streets

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -45,5 +45,5 @@ class TestWeights:
 
         db_cent_false = mm.DistanceBand(self.df_buildings, 100, centroid=False)
         assert sorted(db_cent_false.neighbors[0]) == sorted(
-            [125, 133, 114, 134, 113, 121]
+            [111, 112, 115, 130, 125, 133, 114, 120, 134, 113, 121]
         )


### PR DESCRIPTION
`DistanceBand` changed geometry of original gdf. Copy is needed here.

Plus some forgotten cleanup ahead of 0.4.1 bug fix release.