### PR TITLE
TST: different order of geometries

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -157,4 +157,4 @@ class TestElements:
 
         assert links.edgeID_values.apply(lambda x: sum(x)).sum() == len(enclosed_tess)
         m = enclosed_tess["uID"] == 110
-        assert links[m].iloc[0]["edgeID_keys"] == [0, 34]
+        assert sorted(links[m].iloc[0]["edgeID_keys"]) == [0, 34]

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -156,4 +156,5 @@ class TestElements:
         links = mm.get_network_ratio(enclosed_tess, self.df_streets, initial_buffer=10)
 
         assert links.edgeID_values.apply(lambda x: sum(x)).sum() == len(enclosed_tess)
-        assert links.loc[149, "edgeID_keys"] == [13, 30, 27, 29, 28]
+        m = enclosed_tess["uID"] == 110
+        assert links[m].iloc[0]["edgeID_keys"] == [0, 34]


### PR DESCRIPTION
GEOS3.9 returns geometries in a different order, therefore we cannot rely on `iloc` in tests