### PR TITLE
BUG: node ID doesn't match ID in weights

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,16 @@ on:
     - cron: "0 0 * * 1,4"
 
 jobs:
+  Linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
+
   Test:
+    needs: Linting
     name: ${{ matrix.os }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -57,10 +66,5 @@ jobs:
         if: contains(matrix.env, 'latest.yaml') && contains(matrix.os, 'ubuntu')
         run: |
           ci/envs/test_user_guide.sh
-
-      - name: Black
-        shell: bash -l {0}
-        run: |
-          black --check .
 
       - uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ run/
 .vscode
 .asv
 dask-worker-space
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/python/black
+-   repo: https://github.com/psf/black
     rev: 21.4b2
     hooks:
     -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 21.4b2
     hooks:
     -   id: black
         language_version: python3

--- a/benchmarks/bench_intensity.py
+++ b/benchmarks/bench_intensity.py
@@ -60,5 +60,8 @@ class TimeIntensity:
 
     def time_Density(self):
         mm.Density(
-            self.df_tessellation, self.df_buildings["fl_area"], self.sw3, "uID",
+            self.df_tessellation,
+            self.df_buildings["fl_area"],
+            self.sw3,
+            "uID",
         )

--- a/ci/envs/dev.yaml
+++ b/ci/envs/dev.yaml
@@ -12,7 +12,6 @@ dependencies:
   - codecov
   - pip
   - osmnx
-  - black=19.10b0
   - nose
   - inequality
   - pygeos

--- a/ci/envs/latest.yaml
+++ b/ci/envs/latest.yaml
@@ -17,6 +17,5 @@ dependencies:
   - matplotlib
   - jupyter
   - inequality
-  - black=19.10b0
   - pygeos
   - dask

--- a/ci/envs/stable.yaml
+++ b/ci/envs/stable.yaml
@@ -10,8 +10,7 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - mapclassify=2.4.2
+  - mapclassify
   - osmnx
-  - black=19.10b0
   - pygeos
   - inequality

--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -399,7 +399,7 @@ def simpson_diversity(data, bins=None, categorical=False, categories=None):
             raise ImportError("The 'mapclassify' package is required")
 
     def p(n, N):
-        """ Relative abundance """
+        """Relative abundance"""
         if n == 0:
             return 0
         return float(n) / N
@@ -690,7 +690,7 @@ def shannon_diversity(data, bins=None, categorical=False, categories=None):
             raise ImportError("The 'mapclassify' package is required")
 
     def p(n, N):
-        """ Relative abundance """
+        """Relative abundance"""
         if n == 0:
             return 0
         return (float(n) / N) * ln(float(n) / N)

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -223,7 +223,13 @@ class Tessellation:
             )
 
             self.tessellation = self._enclosed_tessellation(
-                gdf, enclosures, unique_id, enclosure_id, threshold, use_dask, n_chunks,
+                gdf,
+                enclosures,
+                unique_id,
+                enclosure_id,
+                threshold,
+                use_dask,
+                n_chunks,
             )
         else:
             if isinstance(limit, (gpd.GeoSeries, gpd.GeoDataFrame)):

--- a/momepy/preprocessing.py
+++ b/momepy/preprocessing.py
@@ -595,7 +595,8 @@ def _extend_line(coords, target, tolerance, snap=True):
     """
     if snap:
         extrapolation = _get_extrapolated_line(
-            coords[-4:] if len(coords.shape) == 1 else coords[-2:].flatten(), tolerance,
+            coords[-4:] if len(coords.shape) == 1 else coords[-2:].flatten(),
+            tolerance,
         )
         int_idx = target.sindex.query(extrapolation, predicate="intersects")
         intersection = pygeos.intersection(

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -417,10 +417,9 @@ def nx_to_gdf(net, points=True, lines=True, spatial_weights=False, nodeID="nodeI
 
         warnings.warn("Approach is not set. Defaulting to 'primal'.")
 
-    nid = 1
-    for n in net:
+    for nid, n in enumerate(net):
         net.nodes[n][nodeID] = nid
-        nid += 1
+
     return _primal_to_gdf(
         net, points=points, lines=lines, spatial_weights=spatial_weights, nodeID=nodeID
     )

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -188,7 +188,11 @@ class TestDiversity:
         )
 
         perc = mm.Percentiles(
-            self.df_tessellation, "area", self.sw, "uID", weighted="linear",
+            self.df_tessellation,
+            "area",
+            self.sw,
+            "uID",
+            weighted="linear",
         ).frame
         assert np.all(
             perc.loc[0].values - np.array([997.8086922, 2598.84036762, 4107.14201011])
@@ -209,5 +213,9 @@ class TestDiversity:
 
         with pytest.raises(ValueError, match="'nonsense' is not a valid"):
             mm.Percentiles(
-                self.df_tessellation, "area", self.sw, "uID", weighted="nonsense",
+                self.df_tessellation,
+                "area",
+                self.sw,
+                "uID",
+                weighted="nonsense",
             )

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -187,9 +187,9 @@ class TestIntensity:
             nodes, edges, sw, weighted=True, node_degree="degree"
         ).series
         array = mm.NodeDensity(nodes, edges, W).series
-        assert density.mean() == 0.012690163074599968
-        assert weighted.mean() == 0.023207675994368446
-        assert array.mean() == 0.008554067995928158
+        assert density.mean() == 0.005534125924228438
+        assert weighted.mean() == 0.010090861332429164
+        assert array.mean() == 0.01026753724860306
 
     def test_Density(self):
         sw = mm.sw_high(k=3, gdf=self.df_tessellation, ids="uID")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,11 +62,14 @@ class TestUtils:
         )
 
         dual = mm.gdf_to_nx(self.df_streets, approach="dual", angle="ang")
-        assert dual.edges[
-            (1603499.42326969, 6464328.7520580515),
-            (1603510.1061735682, 6464204.555117119),
-            0,
-        ] == {"ang": 1.0963654487814474}
+        assert (
+            dual.edges[
+                (1603499.42326969, 6464328.7520580515),
+                (1603510.1061735682, 6464204.555117119),
+                0,
+            ]
+            == {"ang": 1.0963654487814474}
+        )
 
         dual = mm.gdf_to_nx(
             self.df_streets, approach="dual", angles=False, multigraph=False
@@ -82,10 +85,13 @@ class TestUtils:
 
         dual = mm.gdf_to_nx(self.df_streets, approach="dual", multigraph=False)
         assert isinstance(nx, networkx.Graph)
-        assert dual.edges[
-            (1603499.42326969, 6464328.7520580515),
-            (1603510.1061735682, 6464204.555117119),
-        ] == {"angle": 1.0963654487814474}
+        assert (
+            dual.edges[
+                (1603499.42326969, 6464328.7520580515),
+                (1603510.1061735682, 6464204.555117119),
+            ]
+            == {"angle": 1.0963654487814474}
+        )
 
         with pytest.raises(ValueError):
             mm.gdf_to_nx(self.df_streets, approach="dual", directed=True)


### PR DESCRIPTION
Changes the behaviour of node ID generated in `nx_to_gdf`to start from 0. 

That also fixes a bug in `NodeDensity`  which we didn't know we had :)

Fixes #273 