### PR TITLE
BUG: properly clip enclosures by limit

### DIFF
--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -944,7 +944,11 @@ def get_network_ratio(df, edges, initial_buffer=500):
 
 
 def enclosures(
-    primary_barriers, limit=None, additional_barriers=None, enclosure_id="eID"
+    primary_barriers,
+    limit=None,
+    additional_barriers=None,
+    enclosure_id="eID",
+    clip=False,
 ):
     """
     Generate enclosures based on passed barriers.
@@ -969,6 +973,8 @@ def enclosures(
         (Multi)LineString geometry is expected.
     enclosure_id : str (default 'eID')
         name of the enclosure_id (to be created).
+    clip : bool (default False)
+        if True, the enclosures will be clipped to the extent of the limit (if given)
 
     Returns
     -------
@@ -1044,7 +1050,7 @@ def enclosures(
             {enclosure_id: range(len(enclosures))}, geometry=enclosures
         )
 
-    if limit is not None:
+    if clip and limit is not None:
 
         return gpd.clip(final_enclosures, limit)
 

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -974,8 +974,8 @@ def enclosures(
     enclosure_id : str (default 'eID')
         name of the enclosure_id (to be created).
     clip : bool (default False)
-        if True, the enclosures will be clipped to the extent of the limit (if given).
-        Requires ``limit`` composed of Polygon or MultiPolygon geometries.
+        if True, returns enclosures with representative point within the limit
+        (if given). Requires ``limit`` composed of Polygon or MultiPolygon geometries.
 
     Returns
     -------
@@ -1054,6 +1054,10 @@ def enclosures(
                 "`limit` requires a GeoDataFrame or GeoSeries with Polygon or "
                 "MultiPolygon geometry to be used with clip=True."
             )
-        return gpd.clip(final_enclosures, limit)
+        _, encl_index = final_enclosures.representative_point().sindex.query_bulk(
+            limit.geometry, predicate="contains"
+        )
+        keep = np.unique(encl_index)
+        return final_enclosures.iloc[keep]
 
     return final_enclosures

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -147,6 +147,11 @@ class TestElements:
                 self.df_streets, gpd.GeoSeries([self.limit]), additional_barrier
             )
 
+        # test clip
+        limit = self.df_streets.unary_union.convex_hull.buffer(-100)
+        encl = mm.enclosures(self.df_streets, limit=gpd.GeoSeries([limit]), clip=True)
+        assert len(encl) == 18
+
     def test_get_network_ratio(self):
         convex_hull = self.df_streets.unary_union.convex_hull
         enclosures = mm.enclosures(self.df_streets, limit=gpd.GeoSeries([convex_hull]))


### PR DESCRIPTION
Ensures that generated enclosures are fully within a `limit` (when provided) by calling `geopandas.clip`.

@matthew-law can you test this patch on your data? I'd also like to know what is the performance hit of doing this (it may be significant). I may add a keyword to controlm whether we should try to clip or not.

closes #287, closes #270