### PR TITLE
small typo in gdf_to_nx

### DIFF
--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -164,7 +164,7 @@ def gdf_to_nx(
     angles : bool, default True
         capture angles between LineStrings as an attribute of a dual graph. Ignored if
         ``approach="primal"``.
-    length : str, default 'angle'
+    angle : str, default 'angle'
         name of attribute of angle between LineStrings which will be saved to graph.
         Ignored if ``approach="primal"``.
 


### PR DESCRIPTION
This PR fixes a minor typo in the [`util.gdf_to_nx()`](https://github.com/martinfleis/momepy/blob/1ddb296fe3e2f17db77c2b20df6f16f89943deca/momepy/utils.py#L167) docstring whereby the `length` keyword is used twice: once correctly describing `length` and once incorrectly describing `angle`.